### PR TITLE
[Feat] Head 공통 컴포넌트 구현

### DIFF
--- a/src/components/Head/index.css.ts
+++ b/src/components/Head/index.css.ts
@@ -1,0 +1,10 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '../../styles/theme.css';
+
+export const headStyle = recipe({
+  variants: {
+    tag: {
+      h1: vars.fonts.head01,
+    },
+  },
+});

--- a/src/components/Head/index.css.ts
+++ b/src/components/Head/index.css.ts
@@ -4,7 +4,13 @@ import { vars } from '../../styles/theme.css';
 export const headStyle = recipe({
   variants: {
     tag: {
-      h1: vars.fonts.head01,
+      h1: vars.fonts.h1,
+      h2: vars.fonts.h2,
+      h3: vars.fonts.h3,
+      h4: vars.fonts.h4,
+      h5: vars.fonts.h5,
+      h6: vars.fonts.h6,
+      h7: vars.fonts.h7,
     },
   },
 });

--- a/src/components/Head/index.css.ts
+++ b/src/components/Head/index.css.ts
@@ -1,5 +1,5 @@
 import { recipe } from '@vanilla-extract/recipes';
-import { vars } from '../../styles/theme.css';
+import { vars } from '@/styles/theme.css';
 
 export const headStyle = recipe({
   variants: {

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -1,5 +1,6 @@
+import { headStyle } from '@/components/Head/index.css';
 import { ComponentPropsWithoutRef } from 'react';
-import { headStyle } from './index.css';
+
 
 type HeadLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 type HeadTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7';

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -1,9 +1,11 @@
 import { ComponentPropsWithoutRef } from 'react';
 import { headStyle } from './index.css';
 
-type HeadType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+type HeadLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+type HeadType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7';
 
-interface HeadProps extends ComponentPropsWithoutRef<'h3'> {
+interface HeadProps extends ComponentPropsWithoutRef<'h1'> {
+  level?: HeadLevel;
   tag?: HeadType;
 }
 
@@ -16,8 +18,8 @@ const HeadTag = {
   h6: 'h6',
 } as const;
 
-const Head = ({ tag = 'h3', ...props }: HeadProps) => {
-  const Tag = HeadTag[tag];
+const Head = ({ level = 'h3', tag = 'h3', ...props }: HeadProps) => {
+  const Tag = HeadTag[level];
 
   return (
     <Tag className={headStyle({ tag: tag })} {...props}>

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -2,11 +2,11 @@ import { ComponentPropsWithoutRef } from 'react';
 import { headStyle } from './index.css';
 
 type HeadLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-type HeadType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7';
+type HeadTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7';
 
-interface HeadProps extends ComponentPropsWithoutRef<'h1'> {
+export interface HeadProps extends ComponentPropsWithoutRef<'h1'> {
   level?: HeadLevel;
-  tag?: HeadType;
+  tag?: HeadTag;
 }
 
 const HeadTag = {

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -1,0 +1,29 @@
+import { ComponentPropsWithoutRef } from 'react';
+import { headStyle } from './index.css';
+
+type HeadType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+interface HeadProps extends ComponentPropsWithoutRef<'h3'> {
+  tag?: HeadType;
+}
+
+const HeadTag = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
+} as const;
+
+const Head = ({ tag = 'h3', ...props }: HeadProps) => {
+  const Tag = HeadTag[tag];
+
+  return (
+    <Tag className={headStyle({ tag: tag })} {...props}>
+      {props.children}
+    </Tag>
+  );
+};
+
+export default Head;

--- a/src/stories/Head.stories.tsx
+++ b/src/stories/Head.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Head from '@/components/Head';
+
+const meta = {
+  title: 'Common/Head',
+  component: Head,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    level: {
+      control: { type: 'radio' },
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+    },
+    tag: {
+      control: { type: 'radio' },
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7'],
+    },
+    children: {
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    level: 'h3',
+    tag: 'h3',
+    children: '텍스트',
+  },
+} satisfies Meta<typeof Head>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <ul style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <li>
+        <Head level="h2" tag="h1">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+      <li>
+        <Head level="h2" tag="h2">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+      <li>
+        <Head level="h2" tag="h3">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+      <li>
+        <Head level="h2" tag="h4">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+      <li>
+        <Head level="h2" tag="h5">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+      <li>
+        <Head level="h2" tag="h6">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+      <li>
+        <Head level="h2" tag="h7">
+          DASH 웨비들 행복 앱잼해~
+        </Head>
+      </li>
+    </ul>
+  ),
+};


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #22


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
Head 공통 컴포넌트를 구현했습니다!
h1 ~ h6 시멘틱 태그를 사용할때 사용하면 됩니다.
시멘틱 태그의 level과 폰트를 자유롭게 주입하기 위해 level, tag 두개의 prop을 받습니다.

- level: h1 ~ h6 의 시멘틱 태그 레벨을 의미
- tag: h1 ~ h7 의 폰트명을 의미

두 prop에 주입되는 값이 동일해서 헷갈릴수 있다고 생각하는데 더 좋은 네이밍이나 방향이 생각나면 알려주세요!

## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
```typescript
<Head level='h1' tag='h2'>진혁이 바보</Head>
```
위의 코드는 h1 시멘틱 태그에 h2 폰트를 적용시킨 예시입니다.

## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
스토리북 확인해주세요!

## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

