### PR TITLE
[Feat] Funnel 구조 초기 세팅

### DIFF
--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,0 +1,49 @@
+import { ReactElement, ReactNode, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+interface StepProps {
+  name: string;
+  children: ReactNode;
+}
+
+interface FunnelProps {
+  children: ReactElement<StepProps>[];
+}
+
+// totalSteps는 Funnel 구조에서 마지막 완료 페이지도 포함한 step 개수이다.
+// completePath는 완료 페이지 이후 리다이렉션하는 페이지 path이다. ex) '/dancer'
+export const useFunnel = (totalSteps: number, completePath: string) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const [currentStep, setCurrentStep] = useState(Number(searchParams.get('step') || 1));
+  const step = searchParams.get('step') || '1';
+
+  const setStep = (stepChange: number) => {
+    const newStep = currentStep + stepChange;
+
+    setCurrentStep(newStep);
+
+    if (newStep < 1) {
+      // 첫 step인데 이전 버튼을 누르는 경우
+      navigate(-1);
+    } else if (newStep > totalSteps) {
+      // 마지막 step
+      navigate(completePath);
+    } else {
+      // 일반적인 step
+      searchParams.set('step', String(newStep));
+      setSearchParams(searchParams);
+    }
+  };
+
+  const Step = ({ children }: StepProps) => <>{children}</>;
+
+  const Funnel = ({ children }: FunnelProps) => {
+    const targetStep = children.find((childStep) => childStep.props.name === String(step));
+
+    return <>{targetStep}</>;
+  };
+
+  return { Funnel, Step, setStep };
+};


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #40 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
Funnel 구조를 쉽게 사용하기 위해 useFunnel 커스텀 훅을 구현하였습니다.


## ⭐ PR Point (To Reviewer)
### [useFunnel 구조]
- `useFunnel(totalSteps: number, completePath: string)`으로 정의되어 있습니다.
  - `totalSteps` : 완료 페이지까지 funnel 구조의 step으로 생각한다.
  - `completePath` : funnel 구조가 끝나고 (완료 후) 리다이렉션 할 페이지 path를 의미한다.

- useFunnel hook의 return 값은 3가지입니다.
  - `Funnel` : 퍼널 구조에서 step을 감싸주는 역할
  - `Step` : 퍼널 구조에서 단계를 나타내는 컴포넌트를 감싸주는 역할
  - `setStep` : step을 이동하는 함수

- `setStep()`은 **-1 | 1**의 값을 줄 수 있다.
  - `-1` : 이전 페이지 (만약 첫 step이라면 이전 페이지로 navigate 된다.)
  - `1` : 다음 페이지 (만약 마지막 step이라면 `completePath`로 navigate 된다.)

### 사용 방법
1. Funnel 구조가 필요한 Page 컴포넌트에서 useFunnel hook으로 return 값을 받는다.
`const { Funnel, Step, setStep } = useFunnel(3, '/reservation'); // total step 개수, redirection 페이지 path
`
2. Funnel/Step을 활용해 필요한 step에 맞게 컴포넌트를 구조화한다.
```ts
<Funnel>
        <Step name="1">
          <StepOne/>
        </Step>

        <Step name="2">
          <StepTwo  />
        </Step>
</Funnel>
```

3. step별 필요한 state는 최상위 페이지 컴포넌트에서 모두 정의한다. (`setStep` 함수는 Props로 전달한다.)
4. 하위 step 컴포넌트에서 ref를 정의하여 input에 지정한다. (set함수로 인한 리렌더링 방지)
5. 이전 버튼은 `setStep(-1)`을 주고, 다음 버튼은 `setStep(1)`와 `setName(nameRef.current.value);`를 같이 준다.


## 📷 Screenshot
**[예시 코드 노션]**
https://peppered-parade-9ba.notion.site/useFunnel-17c081ae8cf9803c98cecc401c1d81c1?pvs=4

## 🔔 ETC
참고한 useFunnel 아티클
- https://github.com/Team-Tiki/tiki-client/blob/develop/apps/client/src/shared/hook/common/useFunnel.tsx
- https://github.com/PICK-PLE/PICKPLE-client/blob/main/src/hooks/useFunnel.tsx
- https://github.com/morib-in/Morib-Client/blob/develop/src/pages/OnboardingPage/hooks/useFunnel.tsx
