### PR TITLE
[Feat] Tag 공통 컴포넌트 스타일 추가

### DIFF
--- a/src/components/Tag/index.css.ts
+++ b/src/components/Tag/index.css.ts
@@ -20,9 +20,7 @@ export const tagStyle = recipe({
         backgroundColor: vars.colors.gray10,
       },
       search: {
-        borderRadius: 2,
-        border: `1px solid ${vars.colors.main03}`,
-
+        color: vars.colors.main03,
         backgroundColor: vars.colors.white,
       },
     },
@@ -41,8 +39,11 @@ export const tagStyle = recipe({
         ...vars.fonts.b2,
       },
       large: {
+        borderRadius: 2,
+        border: `1px solid ${vars.colors.main03}`,
         padding: '0.2rem 0.6rem',
         gap: '1rem',
+        ...vars.fonts.b7,
       },
       thumbnail: {
         borderRadius: '0px 4px 4px 0px',

--- a/src/components/Tag/index.css.ts
+++ b/src/components/Tag/index.css.ts
@@ -19,6 +19,12 @@ export const tagStyle = recipe({
       deadline: {
         backgroundColor: vars.colors.gray10,
       },
+      search: {
+        borderRadius: 2,
+        border: `1px solid ${vars.colors.main03}`,
+
+        backgroundColor: vars.colors.white,
+      },
     },
     size: {
       small: {
@@ -33,6 +39,10 @@ export const tagStyle = recipe({
         padding: '0.3rem 0.8rem',
         gap: '1.2rem',
         ...vars.fonts.b2,
+      },
+      large: {
+        padding: '0.2rem 0.6rem',
+        gap: '1rem',
       },
       thumbnail: {
         borderRadius: '0px 4px 4px 0px',

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -2,8 +2,8 @@ import { ComponentPropsWithoutRef } from 'react';
 import { tagStyle } from '@/components/Tag/index.css';
 
 interface TagProps extends ComponentPropsWithoutRef<'div'> {
-  size: 'small' | 'medium' | 'thumbnail';
-  type: 'genre' | 'level' | 'deadline';
+  size: 'small' | 'medium' | 'large' | 'thumbnail';
+  type: 'genre' | 'level' | 'search' | 'deadline';
 }
 
 const Tag = ({ size, type, children, ...props }: TagProps) => {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -8,7 +8,7 @@ import ClassRegister from '@/pages/instructor/classRegister';
 import InstructorRegister from '@/pages/instructorRegister';
 import Login from '@/pages/login';
 import MyPage from '@/pages/mypage';
-import MyPageReservation from '@/pages/mypage/MyPageReservation';
+import MyPageReservation from '@/pages/mypage/myPageReservation';
 import MyPageReservationDetail from '@/pages/mypage/myPageReservationDetail';
 import Reservation from '@/pages/reservation';
 import Search from '@/pages/search';

--- a/src/stories/Tag.stories.tsx
+++ b/src/stories/Tag.stories.tsx
@@ -11,11 +11,11 @@ const meta = {
   argTypes: {
     size: {
       control: { type: 'radio' },
-      options: ['small', 'medium', 'thumbnail'],
+      options: ['small', 'medium', 'large', 'thumbnail'],
     },
     type: {
       control: { type: 'radio' },
-      options: ['genre', 'level', 'deadline'],
+      options: ['genre', 'level', 'search', 'deadline'],
     },
   },
   args: {
@@ -67,6 +67,13 @@ export const LevelTag: Story = {
   args: {
     type: 'level',
     children: '입문자',
+  },
+};
+export const SearchTag: Story = {
+  args: {
+    type: 'search',
+    size: 'large',
+    children: 'K-POP',
   },
 };
 


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #68 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- 탐색 페이지에서 사용되는 태그 컴포넌트의 스타일을 추가로 작성했습니다. storybook으로 확인 가능합니다.

## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
```ts
<Tag type='search' size='large'>K-POP</Tag>
```

일단은 seach 페이지에서만 사용되는 것 같아서 type을 search로, 크기를 large로 설정해주시면 똑같이 만들어집니다!

## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/282ce3bd-833f-4a44-8b73-8b1092ad069c)


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

