### PR TITLE
[Feat] clsx 라이브러리 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "@vanilla-extract/vite-plugin": "^4.0.19",
     "@vitejs/plugin-react": "^4.3.4",
     "axios": "^1.7.9",
+    "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "vite-tsconfig-paths": "^5.1.4",
-    "react-router-dom": "^7.1.1"
+    "react-router-dom": "^7.1.1",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       axios:
         specifier: ^1.7.9
         version: 1.7.9
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1540,6 +1543,10 @@ packages:
         optional: true
       '@chromatic-com/playwright':
         optional: true
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4278,6 +4285,8 @@ snapshots:
   check-error@2.1.1: {}
 
   chromatic@11.22.0: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/src/components/BoxButton/index.tsx
+++ b/src/components/BoxButton/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { HTMLAttributes } from 'react';
 import { buttonStyle } from '@/components/BoxButton/index.css';
 
@@ -6,12 +7,15 @@ export interface BoxButtonProps extends HTMLAttributes<HTMLButtonElement> {
   isDisabled?: boolean;
 }
 
-const BoxButton = ({ variant = 'primary', isDisabled = false, children, ...props }: BoxButtonProps) => {
+const BoxButton = ({ variant = 'primary', isDisabled = false, children, className, ...props }: BoxButtonProps) => {
   return (
     <button
-      className={buttonStyle({
-        variant,
-      })}
+      className={clsx(
+        className,
+        buttonStyle({
+          variant,
+        })
+      )}
       disabled={isDisabled}
       {...props}>
       {children}

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,11 +1,12 @@
+import clsx from 'clsx';
 import type { ComponentProps } from 'react';
 import { cardStyle } from './index.css';
 
 type CardProps = ComponentProps<'div'>;
 
-const Card = ({ children, ...props }: CardProps) => {
+const Card = ({ children, className, ...props }: CardProps) => {
   return (
-    <div className={cardStyle} {...props}>
+    <div className={clsx(className, cardStyle)} {...props}>
       {children}
     </div>
   );

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -1,20 +1,24 @@
+import clsx from 'clsx';
+import { HTMLAttributes } from 'react';
 import { dividerStyle } from '@/components/Divider/index.css';
 
-interface DividerProps {
+interface DividerProps extends HTMLAttributes<HTMLDivElement> {
   direction?: 'horizontal' | 'vertical';
   color?: 'primary' | 'secondary';
   length?: string | number;
   thickness?: string | number;
 }
+
 const Divider = ({
   direction = 'horizontal',
   color = 'primary',
   length = '100%',
   thickness = '0.1rem',
+  className,
 }: DividerProps) => {
   const sizeStyle =
     direction === 'horizontal' ? { width: length, height: thickness } : { height: length, width: thickness };
-  return <div className={dividerStyle({ direction, color })} style={sizeStyle} />;
+  return <div className={clsx(className, dividerStyle({ direction, color }))} style={sizeStyle} />;
 };
 
 export default Divider;

--- a/src/components/Flex/index.tsx
+++ b/src/components/Flex/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { ElementType, HTMLAttributes } from 'react';
 import { flexStyle } from './index.css';
 
@@ -34,6 +35,7 @@ const Flex = ({
   marginTop,
   marginBottom,
   children,
+  className,
   ...props
 }: FlexProps) => {
   const Element = tag;
@@ -51,16 +53,18 @@ const Flex = ({
 
   return (
     <Element
-      className={flexStyle({
-        direction,
-        align,
-        justify,
-        wrap,
-        grow,
-      })}
+      className={clsx(
+        className,
+        flexStyle({
+          direction,
+          align,
+          justify,
+          wrap,
+          grow,
+        })
+      )}
       style={inlineStyles}
-      {...props}
-    >
+      {...props}>
       {children}
     </Element>
   );

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -1,6 +1,6 @@
-import { headStyle } from '@/components/Head/index.css';
+import clsx from 'clsx';
 import { ComponentPropsWithoutRef } from 'react';
-
+import { headStyle } from '@/components/Head/index.css';
 
 type HeadLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 type HeadTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7';
@@ -19,11 +19,11 @@ const HeadTag = {
   h6: 'h6',
 } as const;
 
-const Head = ({ level = 'h3', tag = 'h3', ...props }: HeadProps) => {
+const Head = ({ level = 'h3', tag = 'h3', className, ...props }: HeadProps) => {
   const Tag = HeadTag[level];
 
   return (
-    <Tag className={headStyle({ tag: tag })} {...props}>
+    <Tag className={clsx(className, headStyle({ tag: tag }))} {...props}>
       {props.children}
     </Tag>
   );

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { ForwardedRef, forwardRef, InputHTMLAttributes } from 'react';
 import * as style from './index.css';
 
@@ -6,12 +7,12 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   isSearch?: boolean;
 }
 
-const Input = ({ isError, isSearch = false, ...props }: InputProps, ref: ForwardedRef<HTMLInputElement>) => {
+const Input = ({ isError, isSearch = false, className, ...props }: InputProps, ref: ForwardedRef<HTMLInputElement>) => {
   return (
     <input
       ref={ref}
       type="text"
-      className={style.inputStyle({ isError, isSearch })}
+      className={clsx(className, style.inputStyle({ isError, isSearch }))}
       placeholder="예시를 써주세요"
       {...props}
     />

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { ComponentPropsWithoutRef } from 'react';
 import { tagStyle } from '@/components/Tag/index.css';
 
@@ -6,9 +7,9 @@ interface TagProps extends ComponentPropsWithoutRef<'div'> {
   type: 'genre' | 'level' | 'deadline';
 }
 
-const Tag = ({ size, type, children, ...props }: TagProps) => {
+const Tag = ({ size, type, children, className, ...props }: TagProps) => {
   return (
-    <div className={tagStyle({ size, type })} {...props}>
+    <div className={clsx(className, tagStyle({ size, type }))} {...props}>
       {children}
     </div>
   );

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { HTMLAttributes } from 'react';
 import { textStyle } from '@/components/Text/index.css';
 
@@ -39,9 +40,9 @@ interface TextProps extends HTMLAttributes<HTMLParagraphElement> {
     | 'black';
 }
 
-const Text = ({ tag = 'b1', color = 'black', children, ...props }: TextProps) => {
+const Text = ({ tag = 'b1', color = 'black', children, className, ...props }: TextProps) => {
   return (
-    <p className={textStyle({ tag, color })} {...props}>
+    <p className={clsx(className, textStyle({ tag, color }))} {...props}>
       {children}
     </p>
   );


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #76


## ✅ 체크 리스트 
- [X] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- clsx 라이브러리를 도입했습니다
- 현재 구현된 공통 컴포넌트 중 tab, header를 제외하고 clsx 라이브러리로 className을 병합시켜줬습니다.

## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
바엑을 사용하면 하나의 컴포넌트에 여러개의 className을 지정하면 하나의 className만 적용됩니다. 따라서 만들어둔 컴포넌트에 새롭게 스타일을 주입하고 싶다면 여러개의 스타일 모듈을 병합해주는 작업을 거쳐야합니다. 이 과정을 쉽게 해주는 라이브러리로 clsx, classNames 두개의 라이브러리가 있습니다!
두 라이브러리 중 clsx 의 성능이 더 좋고 최근 clsx가 치고 올라오는 추세라 clsx를 도입하였습니다. 자세한 비교는 [아티클](https://ux.stories.pe.kr/344)에서 확인하시면 좋을것 같습니다!

사용 방법은 다음과 같습니다.
1. clsx import
2. className={clsx(className, tagStyle({ size, type }))} 로 해당 컴포넌트에서 설정하는 style과 className의 스타일을 병합해줍니다.

```typescript
import clsx from 'clsx';
import { ComponentPropsWithoutRef } from 'react';
import { tagStyle } from '@/components/Tag/index.css';

interface TagProps extends ComponentPropsWithoutRef<'div'> {
  size: 'small' | 'medium' | 'thumbnail';
  type: 'genre' | 'level' | 'deadline';
}

const Tag = ({ size, type, children, className, ...props }: TagProps) => {
  return (
    <div className={clsx(className, tagStyle({ size, type }))} {...props}>
      {children}
    </div>
  );
};

export default Tag;
```

앞으로 공통 컴포넌트에는 무조건 해당 작업을 거쳐야 하고 각자 만들어서 사용하는 컴포넌트에도 필요할 시 적용하여 사용하면 좋을것 같습니다!

## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

