### PR TITLE
[Feat] 클래스 예약 내역 페이지 전체 레이아웃

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,6 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} />
-      <div>DASH</div>
     </QueryClientProvider>
   );
 };

--- a/src/mocks/mockReservationData.ts
+++ b/src/mocks/mockReservationData.ts
@@ -1,0 +1,34 @@
+export const mockReservationData = {
+  reservations: [
+    {
+      reservationId: 1,
+      lessonName: '스트리트 댄스 기초',
+      lessonImageUrl: 'https://example.com/lesson-image.jpg',
+      lessonGenre: '힙합',
+      lessonLevel: '입문자',
+      lessonLocation: '서울특별시 강남구',
+      lessonStartDateTime: '2024-01-17T10:00:00',
+      lessonEndDateTime: '2024-01-17T12:00:00',
+    },
+    {
+      reservationId: 2,
+      lessonName: '컨템포러리 댄스',
+      lessonImageUrl: 'https://example.com/contemporary.jpg',
+      lessonGenre: '컨템포러리',
+      lessonLevel: '초급',
+      lessonLocation: '서울특별시 서초구',
+      lessonStartDateTime: '2025-01-20T14:00:00',
+      lessonEndDateTime: '2025-01-20T16:00:00',
+    },
+    {
+      reservationId: 3,
+      lessonName: '뚝딱아 선생님이 고쳐줄게',
+      lessonImageUrl: 'https://example.com/contemporary.jpg',
+      lessonGenre: '컨템포러리',
+      lessonLevel: '고급',
+      lessonLocation: '서울특별시 서초구',
+      lessonStartDateTime: '2025-01-17T10:00:00',
+      lessonEndDateTime: '2025-01-17T12:00:00',
+    },
+  ],
+};

--- a/src/mocks/mockReservationData.ts
+++ b/src/mocks/mockReservationData.ts
@@ -1,4 +1,4 @@
-export const mockReservationData = {
+export const MOCK_RESERVATION_DATA = {
   reservations: [
     {
       reservationId: 1,

--- a/src/pages/mypage/mypageReservation/index.css.ts
+++ b/src/pages/mypage/mypageReservation/index.css.ts
@@ -1,0 +1,1 @@
+import { style } from '@vanilla-extract/css';

--- a/src/pages/mypage/mypageReservation/index.css.ts
+++ b/src/pages/mypage/mypageReservation/index.css.ts
@@ -2,8 +2,9 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 
 export const layoutStyle = style({
-  height: '100vh',
-  padding: '6.4rem 2rem 3.2rem 2rem',
+  height: '100%',
+
+  padding: '8.4rem 2rem 3.2rem 2rem',
 
   backgroundColor: vars.colors.gray01,
 });

--- a/src/pages/mypage/mypageReservation/index.css.ts
+++ b/src/pages/mypage/mypageReservation/index.css.ts
@@ -2,9 +2,11 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 
 export const layoutStyle = style({
-  height: '100%',
-
-  padding: '8.4rem 2rem 3.2rem 2rem',
+  height: '100vh',
 
   backgroundColor: vars.colors.gray01,
+});
+
+export const containerStyle = style({
+  padding: '8.4rem 2rem 3.4rem 2rem',
 });

--- a/src/pages/mypage/mypageReservation/index.css.ts
+++ b/src/pages/mypage/mypageReservation/index.css.ts
@@ -1,1 +1,9 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const layoutStyle = style({
+  height: '100vh',
+  padding: '6.4rem 2rem 3.2rem 2rem',
+
+  backgroundColor: vars.colors.gray01,
+});

--- a/src/pages/mypage/mypageReservation/index.tsx
+++ b/src/pages/mypage/mypageReservation/index.tsx
@@ -1,7 +1,17 @@
-import * as styles from '@/pages/mypage/mypageReservation/MyPageReservation.css';
+import * as React from 'react';
+import { layoutStyle } from '@/pages/mypage/mypageReservation/index.css';
+import Header from '@/components/Header';
 
 const MyPageReservation = () => {
-  return <div>마이페이지 예약 내역</div>;
+  return (
+    <React.Fragment>
+      <Header.Root isColor={true}>
+        <Header.BackIcon />
+        <Header.Title title="클래스 예약 내역" />
+      </Header.Root>
+      <div className={layoutStyle}></div>
+    </React.Fragment>
+  );
 };
 
 export default MyPageReservation;

--- a/src/pages/mypage/mypageReservation/index.tsx
+++ b/src/pages/mypage/mypageReservation/index.tsx
@@ -1,38 +1,58 @@
-import * as React from 'react';
-import { layoutStyle } from '@/pages/mypage/mypageReservation/index.css';
+import { useNavigate } from 'react-router-dom';
+import { layoutStyle, containerStyle } from '@/pages/mypage/mypageReservation/index.css';
 import BoxButton from '@/components/BoxButton';
 import ClassCard from '@/components/ClassCard';
 import Flex from '@/components/Flex';
 import Header from '@/components/Header';
 import Text from '@/components/Text';
-import { mockReservationData } from '@/mocks/mockReservationData';
+import { MOCK_RESERVATION_DATA } from '@/mocks/mockReservationData';
 import { ReservationCardProps } from '@/types/reservationTypes';
 
 const MyPageReservation = () => {
-  const totalReservation = mockReservationData.reservations.length;
+  const navigate = useNavigate();
+
+  /* API 연결 작업 필요! 추후 수정.
+    const { data, isLoading, isError } = 쿼리리
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (isError) {
+    return <div>예약 내역 데이터를 불러오는 중 오류가 발생했습니다.</div>;
+  }
+  */
+
+  const handleDetailClick = (reservationId: number) => {
+    navigate(`/mypage/reservation/${reservationId}`);
+  };
+  const totalReservation = MOCK_RESERVATION_DATA.reservations.length;
 
   return (
-    <React.Fragment>
+    <div className={layoutStyle}>
       <Header.Root isColor={true}>
         <Header.BackIcon />
         <Header.Title title="클래스 예약 내역" />
       </Header.Root>
-      <div className={layoutStyle}>
+
+      <div className={containerStyle}>
         <Text tag="b2" color="gray9">
           전체 {totalReservation}
         </Text>
         <Flex direction="column" gap="1.2rem" marginTop="1.6rem">
-          {mockReservationData.reservations.map((reservation: ReservationCardProps) => (
+          {MOCK_RESERVATION_DATA.reservations.map((reservation: ReservationCardProps) => (
             <ClassCard key={reservation.reservationId} {...reservation}>
               <BoxButton variant="outline" isDisabled={true}>
                 취소하기
               </BoxButton>
-              <BoxButton variant="outline">상세보기</BoxButton>
+              <BoxButton variant="outline" onClick={() => handleDetailClick(reservation.reservationId)}>
+                상세보기
+              </BoxButton>
             </ClassCard>
           ))}
         </Flex>
       </div>
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/pages/mypage/mypageReservation/index.tsx
+++ b/src/pages/mypage/mypageReservation/index.tsx
@@ -1,0 +1,7 @@
+import * as styles from '@/pages/mypage/mypageReservation/MyPageReservation.css';
+
+const MyPageReservation = () => {
+  return <div>마이페이지 예약 내역</div>;
+};
+
+export default MyPageReservation;

--- a/src/pages/mypage/mypageReservation/index.tsx
+++ b/src/pages/mypage/mypageReservation/index.tsx
@@ -1,15 +1,37 @@
 import * as React from 'react';
 import { layoutStyle } from '@/pages/mypage/mypageReservation/index.css';
+import BoxButton from '@/components/BoxButton';
+import ClassCard from '@/components/ClassCard';
+import Flex from '@/components/Flex';
 import Header from '@/components/Header';
+import Text from '@/components/Text';
+import { mockReservationData } from '@/mocks/mockReservationData';
+import { ReservationCardProps } from '@/types/reservationTypes';
 
 const MyPageReservation = () => {
+  const totalReservation = mockReservationData.reservations.length;
+
   return (
     <React.Fragment>
       <Header.Root isColor={true}>
         <Header.BackIcon />
         <Header.Title title="클래스 예약 내역" />
       </Header.Root>
-      <div className={layoutStyle}></div>
+      <div className={layoutStyle}>
+        <Text tag="b2" color="gray9">
+          전체 {totalReservation}
+        </Text>
+        <Flex direction="column" gap="1.2rem" marginTop="1.6rem">
+          {mockReservationData.reservations.map((reservation: ReservationCardProps) => (
+            <ClassCard key={reservation.reservationId} {...reservation}>
+              <BoxButton variant="outline" isDisabled={true}>
+                취소하기
+              </BoxButton>
+              <BoxButton variant="outline">상세보기</BoxButton>
+            </ClassCard>
+          ))}
+        </Flex>
+      </div>
     </React.Fragment>
   );
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -8,6 +8,7 @@ import ClassRegister from '@/pages/instructor/classRegister';
 import InstructorRegister from '@/pages/instructorRegister';
 import Login from '@/pages/login';
 import MyPage from '@/pages/mypage';
+import MyPageReservation from '@/pages/mypage/mypageReservation';
 import Reservation from '@/pages/reservation';
 import Search from '@/pages/search';
 import { ROUTES_CONFIG } from './routesConfig';
@@ -40,6 +41,10 @@ export const router = createBrowserRouter([
   {
     path: ROUTES_CONFIG.mypage.path,
     element: <MyPage />,
+  },
+  {
+    path: ROUTES_CONFIG.mypageReservation.path,
+    element: <MyPageReservation />,
   },
   {
     path: ROUTES_CONFIG.classRegister.path,

--- a/src/types/reservationTypes.ts
+++ b/src/types/reservationTypes.ts
@@ -1,6 +1,5 @@
-export interface ClassCardProps {
-  lessonId?: number;
-  reservationId?: number;
+export interface ReservationCardProps {
+  reservationId: number;
   lessonName: string;
   lessonImageUrl: string;
   lessonGenre: string;
@@ -8,6 +7,4 @@ export interface ClassCardProps {
   lessonLocation: string;
   lessonStartDateTime: string;
   lessonEndDateTime: string;
-  isReservation?: boolean;
-  children?: React.ReactNode;
 }


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #88 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build) -> Header 제외~~
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- ClassCard 공통 컴포넌트를 이용해서 클래스 예약 내역 조회 전체 페이지 레이아웃을 완성했습니다!!


## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
- Card에 관련된 자세한 사항은 classCard PR과 동일하므로 자세한 내용은 생략하겠습니다! 안에 들어가는 내용은 mockReservationData를 이용해서 실제 api 반환값을 사용하는 것처럼 작성했습니다.
- 상단에 전체 3같은 경우에는 반환값의 length를 이용했습니다.

```ts
 const totalReservation = MOCK_RESERVATION_DATA.reservations.length;
```

## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/96db378f-90f0-4365-b507-fbdf8eb430bd)


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

