### PR TITLE
[Feat] 탐색 페이지 바텀시트 구현

### DIFF
--- a/src/pages/search/TabContainer/TagSection/BottomSheet/index.css.ts
+++ b/src/pages/search/TabContainer/TagSection/BottomSheet/index.css.ts
@@ -1,0 +1,30 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const bottomSheet = style({
+  overflow: 'hidden',
+});
+
+export const overlayStyle = style({
+  position: 'fixed',
+  left: 'calc(50vw - 21.5rem)',
+  bottom: 0,
+  height: '100vh',
+  width: '100%',
+  background: vars.colors.black70,
+  zIndex: 2,
+  cursor: 'pointer',
+});
+
+export const bottomSheetStyle = style({
+  position: 'fixed',
+  height: '50rem',
+  width: '100%',
+  bottom: 0,
+  left: 'calc(50vw - 21.5rem)',
+
+  background: vars.colors.white,
+  padding: '3.6rem 2rem 2.4rem 2rem',
+  zIndex: 3,
+  borderRadius: '16px 16px 0 0',
+});

--- a/src/pages/search/TabContainer/TagSection/BottomSheet/index.css.ts
+++ b/src/pages/search/TabContainer/TagSection/BottomSheet/index.css.ts
@@ -7,7 +7,8 @@ export const bottomSheet = style({
 
 export const overlayStyle = style({
   position: 'fixed',
-  left: 'calc(50vw - 21.5rem)',
+  left: '50%',
+  transform: 'translateX(-50%)',
   bottom: 0,
   height: '100vh',
   width: '100%',
@@ -21,8 +22,8 @@ export const bottomSheetStyle = style({
   height: '50rem',
   width: '100%',
   bottom: 0,
-  left: 'calc(50vw - 21.5rem)',
-
+  left: '50%',
+  transform: 'translateX(-50%)',
   background: vars.colors.white,
   padding: '3.6rem 2rem 2.4rem 2rem',
   zIndex: 3,

--- a/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
@@ -1,16 +1,41 @@
+import { useState } from 'react';
 import { bottomSheetStyle, overlayStyle } from '@/pages/search/TabContainer/TagSection/BottomSheet/index.css';
+import BoxButton from '@/components/BoxButton';
 import Flex from '@/components/Flex';
+import { TabButton, TabList, TabPanel, TabRoot } from '@/components/Tab';
 
 interface BottomSheetProps {
   onClose: () => void;
 }
 
 const BottomSheet = ({ onClose }: BottomSheetProps) => {
+  const [selectedTab, setSelectedTab] = useState(0);
   document.body.style.overflow = 'hidden';
   return (
     <div className={bottomSheetStyle}>
       <div className={overlayStyle} onClick={onClose} />
-      <Flex direction="column" className={bottomSheetStyle}></Flex>
+      <Flex direction="column" className={bottomSheetStyle}>
+        <TabRoot>
+          <TabList>
+            <TabButton isSelected={selectedTab === 0} onClick={() => setSelectedTab(0)} colorScheme="secondary">
+              장르
+            </TabButton>
+            <TabButton isSelected={selectedTab === 1} onClick={() => setSelectedTab(1)} colorScheme="secondary">
+              난이도
+            </TabButton>
+            <TabButton isSelected={selectedTab === 2} onClick={() => setSelectedTab(2)} colorScheme="secondary">
+              기간
+            </TabButton>
+          </TabList>
+          <TabPanel isSelected={selectedTab === 0}>장르</TabPanel>
+          <TabPanel isSelected={selectedTab === 1}>난이도</TabPanel>
+          <TabPanel isSelected={selectedTab === 2}>기간</TabPanel>
+        </TabRoot>
+        <Flex width="100%" gap="0.8rem">
+          <BoxButton variant="secondary">초기화</BoxButton>
+          <BoxButton isDisabled={true}>적용하기</BoxButton>
+        </Flex>
+      </Flex>
     </div>
   );
 };

--- a/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
@@ -6,11 +6,18 @@ import { TabButton, TabList, TabPanel, TabRoot } from '@/components/Tab';
 
 interface BottomSheetProps {
   onClose: () => void;
+  initialTabIndex: number;
 }
 
-const BottomSheet = ({ onClose }: BottomSheetProps) => {
-  const [selectedTab, setSelectedTab] = useState(0);
+interface BottomSheetProps {
+  onClose: () => void;
+  initialTabIndex: number; // 초기 탭 인덱스
+}
+
+const BottomSheet = ({ onClose, initialTabIndex }: BottomSheetProps) => {
+  const [selectedTab, setSelectedTab] = useState(initialTabIndex); // 초기값 설정
   document.body.style.overflow = 'hidden';
+
   return (
     <div className={bottomSheetStyle}>
       <div className={overlayStyle} onClick={onClose} />

--- a/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
@@ -11,11 +11,11 @@ interface BottomSheetProps {
 
 interface BottomSheetProps {
   onClose: () => void;
-  initialTabIndex: number; // 초기 탭 인덱스
+  initialTabIndex: number;
 }
 
 const BottomSheet = ({ onClose, initialTabIndex }: BottomSheetProps) => {
-  const [selectedTab, setSelectedTab] = useState(initialTabIndex); // 초기값 설정
+  const [selectedTab, setSelectedTab] = useState(initialTabIndex);
   document.body.style.overflow = 'hidden';
 
   return (

--- a/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/BottomSheet/index.tsx
@@ -1,0 +1,18 @@
+import { bottomSheetStyle, overlayStyle } from '@/pages/search/TabContainer/TagSection/BottomSheet/index.css';
+import Flex from '@/components/Flex';
+
+interface BottomSheetProps {
+  onClose: () => void;
+}
+
+const BottomSheet = ({ onClose }: BottomSheetProps) => {
+  document.body.style.overflow = 'hidden';
+  return (
+    <div className={bottomSheetStyle}>
+      <div className={overlayStyle} onClick={onClose} />
+      <Flex direction="column" className={bottomSheetStyle}></Flex>
+    </div>
+  );
+};
+
+export default BottomSheet;

--- a/src/pages/search/TabContainer/TagSection/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/index.tsx
@@ -8,6 +8,7 @@ import { IcFilterGray } from '@/assets/svg';
 interface TagItem {
   label: string;
   icon?: JSX.Element;
+  type?: string;
 }
 
 interface TagSectionProps {
@@ -19,8 +20,22 @@ interface TagSectionProps {
 
 const TagSection = ({ displayTags, activeTags, tagSize, tagType }: TagSectionProps) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [selectedTagIndex, setSelectedTagIndex] = useState(0);
 
-  const handleTagClick = () => {
+  const handleTagClick = (index: number) => {
+    if (activeTags.length > 0) {
+      const clickedTag = activeTags[index];
+      const tabMapping: Record<string, number> = {
+        genre: 0,
+        level: 1,
+        dateRange: 2,
+      };
+      if (clickedTag.type) {
+        setSelectedTagIndex(tabMapping[clickedTag.type]);
+      }
+    } else {
+      setSelectedTagIndex(index);
+    }
     setIsBottomSheetOpen(true);
   };
 
@@ -33,15 +48,21 @@ const TagSection = ({ displayTags, activeTags, tagSize, tagType }: TagSectionPro
       <Flex justify="spaceBetween" paddingTop="1.2rem" paddingBottom="1.6rem">
         <Flex gap="0.6rem">
           {displayTags.map((tag, index) => (
-            <Tag className={tagCustomStyle} key={index} size={tagSize} type={tagType} onClick={handleTagClick}>
+            <Tag
+              className={tagCustomStyle}
+              key={index}
+              size={tagSize}
+              type={tagType}
+              onClick={() => handleTagClick(index)} // 태그 클릭 핸들러에 인덱스 전달
+            >
               {tag.label}
               {tag.icon && tag.icon}
             </Tag>
           ))}
         </Flex>
-        {!activeTags.length && <IcFilterGray width={28} onClick={handleTagClick} />}
+        {!activeTags.length && <IcFilterGray width={28} onClick={() => handleTagClick(0)} />}
       </Flex>
-      {isBottomSheetOpen && <BottomSheet onClose={handleBottomSheetClose} />}
+      {isBottomSheetOpen && <BottomSheet onClose={handleBottomSheetClose} initialTabIndex={selectedTagIndex} />}
     </>
   );
 };

--- a/src/pages/search/TabContainer/TagSection/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/index.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
+import BottomSheet from '@/pages/search/TabContainer/TagSection/BottomSheet';
+import { tagCustomStyle } from '@/pages/search/TabContainer/TagSection/index.css';
 import Flex from '@/components/Flex';
 import Tag from '@/components/Tag';
 import { IcFilterGray } from '@/assets/svg';
-import { tagCustomStyle } from './index.css';
 
 interface TagItem {
   label: string;
@@ -16,18 +18,31 @@ interface TagSectionProps {
 }
 
 const TagSection = ({ displayTags, activeTags, tagSize, tagType }: TagSectionProps) => {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const handleTagClick = () => {
+    setIsBottomSheetOpen(true);
+  };
+
+  const handleBottomSheetClose = () => {
+    setIsBottomSheetOpen(false);
+  };
+
   return (
-    <Flex justify="spaceBetween" paddingTop="1.2rem" paddingBottom="1.6rem">
-      <Flex gap="0.6rem">
-        {displayTags.map((tag, index) => (
-          <Tag className={tagCustomStyle} key={index} size={tagSize} type={tagType}>
-            {tag.label}
-            {tag.icon && tag.icon}
-          </Tag>
-        ))}
+    <>
+      <Flex justify="spaceBetween" paddingTop="1.2rem" paddingBottom="1.6rem">
+        <Flex gap="0.6rem">
+          {displayTags.map((tag, index) => (
+            <Tag className={tagCustomStyle} key={index} size={tagSize} type={tagType} onClick={handleTagClick}>
+              {tag.label}
+              {tag.icon && tag.icon}
+            </Tag>
+          ))}
+        </Flex>
+        {!activeTags.length && <IcFilterGray width={28} onClick={handleTagClick} />}
       </Flex>
-      {!activeTags.length && <IcFilterGray width={28} />}
-    </Flex>
+      {isBottomSheetOpen && <BottomSheet onClose={handleBottomSheetClose} />}
+    </>
   );
 };
 

--- a/src/pages/search/TabContainer/TagSection/index.tsx
+++ b/src/pages/search/TabContainer/TagSection/index.tsx
@@ -53,8 +53,7 @@ const TagSection = ({ displayTags, activeTags, tagSize, tagType }: TagSectionPro
               key={index}
               size={tagSize}
               type={tagType}
-              onClick={() => handleTagClick(index)} // 태그 클릭 핸들러에 인덱스 전달
-            >
+              onClick={() => handleTagClick(index)}>
               {tag.label}
               {tag.icon && tag.icon}
             </Tag>

--- a/src/pages/search/TabContainer/index.tsx
+++ b/src/pages/search/TabContainer/index.tsx
@@ -11,6 +11,7 @@ import { defaultSortTagProps } from '@/types/defaultSortTag';
 interface TagItem {
   label: string;
   icon?: JSX.Element;
+  type?: string;
 }
 
 interface TabContainerProps {
@@ -25,16 +26,18 @@ const TabContainer = ({ defaultSortTags, genre, level, startDate, endDate }: Tab
   const [selectedTab, setSelectedTab] = useState(0);
 
   const activeTags: TagItem[] = [
-    { condition: genre, label: genre },
-    { condition: level, label: level },
+    { condition: genre, label: genre, type: 'genre' },
+    { condition: level, label: level, type: 'level' },
     {
       condition: startDate && endDate,
       label: `${startDate} ~ ${endDate}`,
+      type: 'dateRange',
     },
   ]
     .filter((tag) => tag.condition)
     .map((tag) => ({
       label: tag.label as string,
+      type: tag.type,
       icon: <IcXMain04 width={18} height={18} />,
     }));
 


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #110 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- 탐색 페이지 바텀 시트 구현
- 탐색 페이지 바텀 시트 탭 컴포넌트 배치


## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->

```typescript
document.body.style.overflow = 'hidden';
```
바텀시트가 올라왔을 때, 뒷배경이 스크롤 되지 않도록 해당 코드 추가해 주었습니다.

## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

https://github.com/user-attachments/assets/670c0b19-df4f-4b09-bfb1-d45b8b5979b2




## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

