### PR TITLE
[Fix] Funnel 구조 첫 번째 step에서 이전 페이지 이동 안 되는 문제 해결

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,14 +1,17 @@
 import clsx from 'clsx';
-import React from 'react';
-import { ComponentPropsWithoutRef } from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Head from '@/components/Head';
-import { headerRootStyle, backIconStyle, titleStyle, closeIconStyle } from '@/components/Header/index.css';
+import { backIconStyle, closeIconStyle, headerRootStyle, titleStyle } from '@/components/Header/index.css';
 import { IcBack, IcClose } from '@/assets/svg';
 
 interface HeaderRootProps extends ComponentPropsWithoutRef<'div'> {
   children: React.ReactNode;
   isColor?: boolean;
+}
+
+interface BackIconProps {
+  onFunnelBackClick?: () => void;
 }
 
 interface TitleProps {
@@ -23,9 +26,15 @@ const HeaderRoot = ({ children, isColor = false, className }: HeaderRootProps): 
   return <div className={clsx(className, headerRootStyle({ isColor }))}>{children}</div>;
 };
 
-const BackIcon = (): JSX.Element => {
+const BackIcon = ({ onFunnelBackClick }: BackIconProps): JSX.Element => {
   const navigate = useNavigate();
   const handleBackClick = () => {
+    // Funnel 구조에서는 이전 버튼 누를 시 setStep(-1)을 해준다.
+    if (onFunnelBackClick) {
+      onFunnelBackClick();
+      return;
+    }
+
     navigate(-1);
   };
   return (

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -33,7 +33,7 @@ export const useFunnel = (totalSteps: number, completePath: string) => {
     } else {
       // 일반적인 step
       searchParams.set('step', String(newStep));
-      setSearchParams(searchParams);
+      setSearchParams(searchParams, { replace: true });
     }
   };
 

--- a/src/pages/instructorRegister/index.tsx
+++ b/src/pages/instructorRegister/index.tsx
@@ -17,7 +17,7 @@ const InstructorRegister = () => {
   return (
     <>
       <Header.Root isColor={true}>
-        {currentStep < TOTAL_STEP && <Header.BackIcon />}
+        {currentStep < TOTAL_STEP && <Header.BackIcon onFunnelBackClick={() => setStep(-1)} />}
         <Header.CloseIcon onClick={() => console.log('hi')} />
       </Header.Root>
       {currentStep < TOTAL_STEP && (


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #132  


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
Funnel 구조 첫 번째 step에서 이전 페이지 이동 안 되는 문제를 해결 하였습니다.


## ⭐ PR Point (To Reviewer)
### 1. Funnel step이 이전 아이콘 누르면 Progress bar에 적용이 안되는 문제

해당 문제를 해결하기 위해서는 근본적으로 Header 컴포넌트 이전 Back아이콘을 누르면 `useFunnel`의 `setStep()`함수를 실행하도록 해야하는데 기존의 Header컴포넌트에는 고정적으로 `navigate(-1)`이 있기 때문에 고민을 많이 하게 되었습니다.
이를 함수를 주입하도록 동적 분기 처리하면 이 문제는 해결되기는 하지만 이렇게 공통 컴포넌트를 제가 수정하면 다른 view에서 쓰는 Header를 모두 바꿔야 하는 문제가 생기는 것을 파악했습니다.

그래서 저는 이를 Funnel일 경우와 일반적인 경우를 분기 처리하도록 구현하였습니다. `optional`로 `onFunnelBackClick`를 주도록 하여 Funnel일 경우는 `setStep`함수를 전달하도록 분기 처리 하였습니다!

```ts
const BackIcon = ({ onFunnelBackClick }: BackIconProps): JSX.Element => {
  const navigate = useNavigate();
  const handleBackClick = () => {
    // Funnel 구조에서는 이전 버튼 누를 시 setStep(-1)을 해준다.
    if (onFunnelBackClick) {
      onFunnelBackClick();
      return;
    }

    navigate(-1);
  };
//...
};
```

### 2. Funnel step이 1일 때 이전 아이콘 누르면 이전 페이지 이동이 안되는 문제
문제가 되는 플로우는 아래와 같습니다.

`step 1` -> (다음 버튼) -> `step 2` -> (다음 버튼) -> `step3` 으로는 잘 가지고
`step 3` -> (이전 버튼) -> `step 2` -> (이전 버튼) -> `step 1` 까지는 잘 가지는데 이 `step 1`에서 이전 버튼을 누르면 이전 페이지로 가야하는데 이상하게 `step 2`로 다시 돌아가는 문제가 발생한 것입니다.

이는 이전 step으로 가는 것도 `history`에 쌓이는 문제이지 않을까라는 생각으로 접근을 했고 `setSearchParams`에서 history를 저장하지 않는 속성인 `{ replace: true `}를 사용해보았습니다!
그렇게 하니 원하는 동작이 잘 되는 것을 확인했습니다! 

`setSearchParams(searchParams, { replace: true });`

## 📷 Screenshot
https://github.com/user-attachments/assets/1e493a63-37ce-41e9-bac2-379f0dacdb8d



## 🔔 ETC
**[setSearchParams replace 관련 참고 자료]**
https://1seul.tistory.com/105
