### PR TITLE
[Design] 탐색페이지 바텀시트 애니메이션 적용

### DIFF
--- a/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.css.ts
+++ b/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.css.ts
@@ -1,7 +1,7 @@
-import { style } from '@vanilla-extract/css';
+import { style, keyframes } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 
-export const bottomSheet = style({
+export const bottomSheetContainerStyle = style({
   overflow: 'hidden',
 });
 
@@ -15,6 +15,32 @@ export const overlayStyle = style({
   background: vars.colors.black70,
   zIndex: 2,
   cursor: 'pointer',
+});
+
+const slideIn = keyframes({
+  from: {
+    transform: 'translate(-50%, 100%)',
+  },
+  to: {
+    transform: 'translate(-50%, 0)',
+  },
+});
+
+const slideOut = keyframes({
+  from: {
+    transform: 'translate(-50%, 0)',
+  },
+  to: {
+    transform: 'translate(-50%, 100%)',
+  },
+});
+
+export const bottomSheetVisible = style({
+  animation: `${slideIn} 0.3s ease-out forwards`,
+});
+
+export const bottomSheetHidden = style({
+  animation: `${slideOut} 0.3s ease-in forwards`,
 });
 
 export const bottomSheetStyle = style({

--- a/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.css.ts
+++ b/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.css.ts
@@ -5,6 +5,32 @@ export const bottomSheetContainerStyle = style({
   overflow: 'hidden',
 });
 
+const fadeIn = keyframes({
+  from: {
+    opacity: 0,
+  },
+  to: {
+    opacity: 1,
+  },
+});
+
+const fadeOut = keyframes({
+  from: {
+    opacity: 1,
+  },
+  to: {
+    opacity: 0,
+  },
+});
+
+export const overlayVisible = style({
+  animation: `${fadeIn} 0.3s ease-out forwards`,
+});
+
+export const overlayHidden = style({
+  animation: `${fadeOut} 0.3s ease-in forwards`,
+});
+
 export const overlayStyle = style({
   position: 'fixed',
   left: '50%',

--- a/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.tsx
+++ b/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.tsx
@@ -4,6 +4,9 @@ import {
   bottomSheetStyle,
   genreButtonContainerStyle,
   overlayStyle,
+  bottomSheetHidden,
+  bottomSheetVisible,
+  bottomSheetContainerStyle,
 } from '@/pages/search/components/TabContainer/TagSection/BottomSheet/index.css';
 import BoxButton from '@/components/BoxButton';
 import Flex from '@/components/Flex';
@@ -43,6 +46,15 @@ const BottomSheet = ({
   const [selectedLevelTitle, setSelectedLevelTitle] = useState<string | null>(level);
   const [selectedStartDate, setSelectedStartDate] = useState<string>(startDate);
   const [selectedEndDate, setSelectedEndDate] = useState<string>(endDate);
+  const [isClosing, setIsClosing] = useState(false);
+
+  const handleClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      document.body.style.overflow = '';
+      onClose();
+    }, 300); // 애니메이션 지속 시간과 동일하게 설정
+  };
 
   document.body.style.overflow = 'hidden';
 
@@ -56,11 +68,6 @@ const BottomSheet = ({
     setEndDate(selectedEndDate);
     setGenre(selectedGenre);
     handleClose();
-  };
-
-  const handleClose = () => {
-    document.body.style.overflow = '';
-    onClose();
   };
 
   const handleReset = () => {
@@ -80,9 +87,9 @@ const BottomSheet = ({
   };
 
   return (
-    <div className={bottomSheetStyle}>
+    <div className={bottomSheetContainerStyle}>
       <div className={overlayStyle} onClick={handleClose} />
-      <Flex direction="column" className={bottomSheetStyle}>
+      <Flex direction="column" className={`${bottomSheetStyle} ${isClosing ? bottomSheetHidden : bottomSheetVisible}`}>
         <TabRoot>
           <TabList>
             <TabButton isSelected={selectedTab === 0} onClick={() => setSelectedTab(0)} colorScheme="secondary">

--- a/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.tsx
+++ b/src/pages/search/components/TabContainer/TagSection/BottomSheet/index.tsx
@@ -7,6 +7,8 @@ import {
   bottomSheetHidden,
   bottomSheetVisible,
   bottomSheetContainerStyle,
+  overlayHidden,
+  overlayVisible,
 } from '@/pages/search/components/TabContainer/TagSection/BottomSheet/index.css';
 import BoxButton from '@/components/BoxButton';
 import Flex from '@/components/Flex';
@@ -53,7 +55,7 @@ const BottomSheet = ({
     setTimeout(() => {
       document.body.style.overflow = '';
       onClose();
-    }, 300); // 애니메이션 지속 시간과 동일하게 설정
+    }, 300);
   };
 
   document.body.style.overflow = 'hidden';
@@ -88,7 +90,7 @@ const BottomSheet = ({
 
   return (
     <div className={bottomSheetContainerStyle}>
-      <div className={overlayStyle} onClick={handleClose} />
+      <div className={`${overlayStyle} ${isClosing ? overlayHidden : overlayVisible}`} onClick={handleClose} />
       <Flex direction="column" className={`${bottomSheetStyle} ${isClosing ? bottomSheetHidden : bottomSheetVisible}`}>
         <TabRoot>
           <TabList>

--- a/src/pages/search/components/TabContainer/TagSection/index.tsx
+++ b/src/pages/search/components/TabContainer/TagSection/index.tsx
@@ -66,7 +66,7 @@ const TagSection = ({
 
   return (
     <>
-      <Flex gap="15.2rem" paddingTop="1.2rem" paddingBottom="1.6rem">
+      <Flex justify="spaceBetween" paddingTop="1.2rem" paddingBottom="1.6rem" width="100%">
         <Flex gap="0.6rem">
           {displayTags.map((tag, index) => (
             <Tag

--- a/src/pages/search/components/TabContainer/index.css.ts
+++ b/src/pages/search/components/TabContainer/index.css.ts
@@ -6,9 +6,3 @@ export const divCustomStyle = style({
   flexWrap: 'wrap',
   justifyContent: 'space-between',
 });
-
-export const dropdownDivStyle = style({
-  position: 'relative',
-  top: 10,
-  left: 199.5,
-});

--- a/src/pages/search/components/TabContainer/index.tsx
+++ b/src/pages/search/components/TabContainer/index.tsx
@@ -3,7 +3,7 @@ import ClassItem from '@/pages/home/components/ClassItem';
 import DancerList from '@/pages/search/components/DancerList';
 import TagSection from '@/pages/search/components/TabContainer/TagSection';
 import Dropdown from '@/pages/search/components/TabContainer/TagSection/Dropdown';
-import { divCustomStyle, dropdownDivStyle } from '@/pages/search/components/TabContainer/index.css';
+import { divCustomStyle } from '@/pages/search/components/TabContainer/index.css';
 import { CLASS_LIST, DANCER_LIST } from '@/pages/search/mocks/index';
 import { defaultSortTagProps } from '@/pages/search/types/defaultSortTag';
 import Flex from '@/components/Flex';
@@ -69,31 +69,32 @@ const TabContainer = ({
     <Flex direction="column" paddingTop="8.4rem" width="100%" paddingLeft="2rem" paddingRight="2rem">
       <Flex align="center" width="100%" justify="spaceBetween" position="relative">
         <TabRoot>
-          <TabList>
-            <TabButton isSelected={selectedTab === 0} onClick={() => setSelectedTab(0)} colorScheme="primary">
-              클래스
-            </TabButton>
-            <TabButton isSelected={selectedTab === 1} onClick={() => setSelectedTab(1)} colorScheme="primary">
-              댄서
-            </TabButton>
-            <div className={dropdownDivStyle}>
-              <Dropdown.Root>
-                <Dropdown.Trigger>
-                  <Flex align="center">
-                    <Text tag="b7" color="gray7">
-                      {selectedLabel}
-                    </Text>
-                    <IcArrowUnderGray width={14} />
-                  </Flex>
-                </Dropdown.Trigger>
-                <Dropdown.Content>
-                  <Dropdown.Item label="최신 등록순" onClick={() => setSelectedLabel('최신 등록순')} />
-                  <Dropdown.Item label="찜이 많은순" onClick={() => setSelectedLabel('찜이 많은순')} />
-                  <Dropdown.Item label="마감 임박순" onClick={() => setSelectedLabel('마감 임박순')} />
-                </Dropdown.Content>
-              </Dropdown.Root>
-            </div>
-          </TabList>
+          <Flex justify="spaceBetween">
+            <TabList>
+              <TabButton isSelected={selectedTab === 0} onClick={() => setSelectedTab(0)} colorScheme="primary">
+                클래스
+              </TabButton>
+              <TabButton isSelected={selectedTab === 1} onClick={() => setSelectedTab(1)} colorScheme="primary">
+                댄서
+              </TabButton>
+            </TabList>
+            <Dropdown.Root>
+              <Dropdown.Trigger>
+                <Flex align="center">
+                  <Text tag="b7" color="gray7">
+                    {selectedLabel}
+                  </Text>
+                  <IcArrowUnderGray width={14} />
+                </Flex>
+              </Dropdown.Trigger>
+              <Dropdown.Content>
+                <Dropdown.Item label="최신 등록순" onClick={() => setSelectedLabel('최신 등록순')} />
+                <Dropdown.Item label="찜이 많은순" onClick={() => setSelectedLabel('찜이 많은순')} />
+                <Dropdown.Item label="마감 임박순" onClick={() => setSelectedLabel('마감 임박순')} />
+              </Dropdown.Content>
+            </Dropdown.Root>
+          </Flex>
+
           <TabPanel isSelected={selectedTab === 0}>
             <TagSection
               displayTags={displayTags}


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #155 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- keyframe 적용해주어 바텀시트 열리고 닫히는 애니메이션 적용해주었습니다.
- 탐색페이지 반응형시 width값 100% 먹히지 않는 이슈 해결했습니다.

## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->


## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

https://github.com/user-attachments/assets/eb72a710-97a2-4337-af05-9419ac989f49




## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

