### PR TITLE
[Api] 로그아웃 api 연결 및 토큰 권한 api 수정

### DIFF
--- a/src/apis/auth/axios/index.ts
+++ b/src/apis/auth/axios/index.ts
@@ -1,4 +1,5 @@
 import { instance } from '@/apis/api';
+import { API_URL } from '@/apis/constants/apiURL';
 
 export interface loginTypes {
   redirectUrl: string;
@@ -9,4 +10,9 @@ export const kakaoLogin = async (redirectUrl: string, code: string) => {
   const response = await instance.post(`/api/v1/auth/login`, { provider: 'KAKAO', redirectUrl, code });
 
   return response;
+};
+
+// 로그아웃
+export const postLogout = async () => {
+  await instance.post(API_URL.AUTH_LOGOUT);
 };

--- a/src/apis/auth/quries/index.ts
+++ b/src/apis/auth/quries/index.ts
@@ -2,8 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { instance } from '@/apis/api';
-import { kakaoLogin, loginTypes } from '@/apis/auth/axios';
-import { setStorage } from '@/utils/handleToken';
+import { kakaoLogin, loginTypes, postLogout } from '@/apis/auth/axios';
+import { clearStorage, setStorage } from '@/utils/handleToken';
 import { ROUTES_CONFIG } from '@/routes/routesConfig';
 
 export const useLoginMutation = () => {
@@ -30,6 +30,20 @@ export const useLoginMutation = () => {
 
     onError: (error: AxiosError) => {
       if (!error.response) return;
+    },
+  });
+};
+
+// 로그아웃
+export const usePostLogout = () => {
+  return useMutation({
+    mutationFn: postLogout,
+    onSuccess: () => {
+      clearStorage();
+      window.location.reload();
+    },
+    onError: (error: AxiosError) => {
+      console.error('Logout failed:', error);
     },
   });
 };

--- a/src/apis/common/axios/index.ts
+++ b/src/apis/common/axios/index.ts
@@ -11,7 +11,7 @@ export const postImage = async (formData: FormData) => {
 };
 
 export const postRole = async () => {
-  const { data } = await instance.post(API_URL.AUTH_ROLE, {});
+  const { data } = await instance.post(API_URL.AUTH_ROLE);
 
   return data;
 };

--- a/src/apis/common/queries/index.ts
+++ b/src/apis/common/queries/index.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { postImage, postRole } from '@/apis/common/axios';
 import { QUERY_KEYS } from '@/apis/constants/queryKey';
 import queryClient from '@/queryClient';
-import { RoleType } from '@/types/roleTypes';
+import { RoleApiResponse } from '@/types/roleTypes';
 
 export const useImageMutation = () => {
   return useMutation({
@@ -13,8 +13,8 @@ export const useImageMutation = () => {
   });
 };
 
-export const useGetRole = (options?: Partial<UseQueryOptions<RoleType>>) => {
-  return useQuery<RoleType>({
+export const useGetRole = (options?: Partial<UseQueryOptions<RoleApiResponse>>) => {
+  return useQuery<RoleApiResponse>({
     queryKey: [QUERY_KEYS.AUTH_ROLE],
     queryFn: postRole,
     ...options,

--- a/src/pages/home/components/BottomSection/index.tsx
+++ b/src/pages/home/components/BottomSection/index.tsx
@@ -2,9 +2,16 @@ import * as styles from '@/pages/home/components/BottomSection/index.css';
 import { LIST_DATA } from '@/pages/mypage/constants/myPageList';
 import Divider from '@/components/Divider';
 import Flex from '@/components/Flex';
+import { usePostLogout } from '@/apis/auth/quries';
 import { IcArrowRightSmallGray0432, IcArrowRightSmallGray0732 } from '@/assets/svg';
 
 const BottomSection = ({ isInstructor }: { isInstructor: boolean }) => {
+  const { mutate: logout } = usePostLogout();
+
+  const handleLogout = () => {
+    logout();
+  };
+
   return (
     <Flex>
       <ul className={styles.ulStyle}>
@@ -16,7 +23,10 @@ const BottomSection = ({ isInstructor }: { isInstructor: boolean }) => {
 
           return (
             <>
-              <li key={item.id} className={`${styles.listStyle} ${isDisabled ? styles.disabledStyle : ''}`}>
+              <li
+                key={item.id}
+                className={`${styles.listStyle} ${isDisabled ? styles.disabledStyle : ''}`}
+                onClick={item.label === '로그아웃' ? handleLogout : undefined}>
                 <p>{item.label}</p>
                 <ArrowIcon width={32} height={32} />
               </li>

--- a/src/pages/home/components/MyPage/index.tsx
+++ b/src/pages/home/components/MyPage/index.tsx
@@ -26,7 +26,7 @@ const MyPage = ({ showMyPage, onClose }: MyPageProps) => {
     lessonCount: null,
   };
 
-  const isInstructor = role === 'TEACHER';
+  const isInstructor = role?.role === 'TEACHER';
 
   const handleClickOutside = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {

--- a/src/types/roleTypes.ts
+++ b/src/types/roleTypes.ts
@@ -1,2 +1,4 @@
 // 토큰 권한 확인
-export type RoleType = 'MEMBER' | 'TEACHER';
+export interface RoleApiResponse {
+  role: string;
+}


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #219 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- 토큰권한 API를 수정했습니다.
```ts
export interface RoleApiResponse {
  role: string;
}
``` 
많이 졸렸었나.. 왜 전에 그렇게 적었었을까요...

또 role에 대한 값은 그 안 role에 있기 때문에

 ` const isInstructor = role?.role === 'TEACHER';` role?.role로 작성해주었더니 정상적으로 작동했습니다.

- 로그아웃 api를 연결했습니다. 로그아웃은 Auth라고 생각해 홈에서 사용되지만 auth 폴더에서 작성했습니다.
```ts
export const postLogout = async () => {
  await instance.post(API_URL.AUTH_LOGOUT);
};

export const usePostLogout = () => {
  return useMutation({
    mutationFn: postLogout,
    onSuccess: () => {
      clearStorage();
      window.location.reload();
    },
    onError: (error: AxiosError) => {
      console.error('Logout failed:', error);
    },
  });
};
```

로그아웃 post에 대한 요청이 성공하면 로컬 스토리지에있는 액세스토큰과 리프레쉬 토큰을 지우고, 창을 리로드합니다. 처음에 navigate('/')으로 가게 했었는데, 생각해보니 마이페이지는 이미 홈 주소 위에 있는 컴포넌트라 navigate가 무소용... 이여서  window.location.reload();로 새로고침 시켜주었습니다!

## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->


## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

https://github.com/user-attachments/assets/fa1b9ce4-ed38-48f6-94e9-25e88c2ab666



## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

