### PR TITLE
[Feat] 탐색페이지 네비게이트 설정

### DIFF
--- a/src/apis/dancer/queries/index.ts
+++ b/src/apis/dancer/queries/index.ts
@@ -6,7 +6,7 @@ import { getDancerDetail } from '@/apis/dancer/axios';
 
 export const useGetDancerDetail = (teacherId: string) => {
   return useQuery<DancerDetailApiResponse, AxiosError>({
-    queryKey: [QUERY_KEYS.TEACHER_DETAIL],
+    queryKey: [QUERY_KEYS.TEACHER_DETAIL, teacherId],
     queryFn: () => getDancerDetail(teacherId),
   });
 };

--- a/src/pages/home/components/GenreItem/index.tsx
+++ b/src/pages/home/components/GenreItem/index.tsx
@@ -4,11 +4,12 @@ import Text from '@/components/Text';
 interface GenreItemProps {
   medalIcon: JSX.Element;
   genre: string;
+  onClick: () => void;
 }
 
-const GenreItem = ({ medalIcon, genre }: GenreItemProps) => {
+const GenreItem = ({ medalIcon, genre, onClick }: GenreItemProps) => {
   return (
-    <li className={containerStyle}>
+    <li className={containerStyle} onClick={onClick}>
       <div className={medalStyle}>{medalIcon}</div>
 
       <Text tag="b2" className={genreStyle}>

--- a/src/pages/home/components/PopularGenre/index.tsx
+++ b/src/pages/home/components/PopularGenre/index.tsx
@@ -1,13 +1,21 @@
+import { useNavigate } from 'react-router-dom';
 import GenreItem from '@/pages/home/components/GenreItem';
 import { genreWrapperStyle } from '@/pages/home/components/LessonItem/index.css';
 import { GENRE_ICONS } from '@/pages/home/constants';
 import Flex from '@/components/Flex';
 import Head from '@/components/Head';
 import { useGetPopularGenres } from '@/apis/home/queries';
+import { ROUTES_CONFIG } from '@/routes/routesConfig';
 import { genreMapping } from '@/constants';
 
 const PopularGenre = () => {
   const { data } = useGetPopularGenres();
+
+  const navigate = useNavigate();
+
+  const handleGenreClick = (genre: string) => {
+    navigate(`${ROUTES_CONFIG.search.path}?genre=${genre}`);
+  };
 
   return (
     <div className={genreWrapperStyle}>
@@ -17,7 +25,12 @@ const PopularGenre = () => {
 
       <Flex tag="ul" gap="0.7rem" marginTop="2rem">
         {data?.genres.map((genre, index) => (
-          <GenreItem key={`${index}-${genre}`} medalIcon={GENRE_ICONS[index]} genre={genreMapping[genre]} />
+          <GenreItem
+            key={`${index}-${genre}`}
+            medalIcon={GENRE_ICONS[index]}
+            genre={genreMapping[genre]}
+            onClick={() => handleGenreClick(genreMapping[genre])}
+          />
         ))}
       </Flex>
     </div>

--- a/src/pages/search/components/TabContainer/DancerList/index.tsx
+++ b/src/pages/search/components/TabContainer/DancerList/index.tsx
@@ -1,8 +1,10 @@
+import { useNavigate } from 'react-router-dom';
 import { dancerImageStyle } from '@/pages/search/components/TabContainer/DancerList/index.css';
 import Flex from '@/components/Flex';
 import Head from '@/components/Head';
 import Tag from '@/components/Tag';
 import { Dancer } from '@/apis/search/queries';
+import { ROUTES_CONFIG } from '@/routes/routesConfig';
 import { genreMapping } from '@/constants/index';
 import { vars } from '@/styles/theme.css';
 
@@ -11,6 +13,11 @@ interface DancerListProps {
 }
 
 const DancerList = ({ dancers }: DancerListProps) => {
+  const navigate = useNavigate();
+
+  const handleDancerClick = (id: number) => {
+    navigate(ROUTES_CONFIG.dancer.path(`${id}`));
+  };
   return (
     <Flex tag="ul" width="100%" direction="column">
       {dancers.map((dancer) => (
@@ -22,7 +29,8 @@ const DancerList = ({ dancers }: DancerListProps) => {
           tag="li"
           borderBottom={`1px solid ${vars.colors.gray01}`}
           width="100%"
-          key={dancer.id}>
+          key={dancer.id}
+          onClick={() => handleDancerClick(dancer.id)}>
           <img src={dancer.profileImage} alt={dancer.nickname} className={dancerImageStyle} />
           <Flex direction="column" gap="0.8rem">
             <Head level="h6" tag="h6">

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import SearchBar from '@/pages/search/components/SearchBar';
-import SearchIntro from '@/pages/search/components/SearchIntro';
 import TabContainer from '@/pages/search/components/TabContainer';
 import { DEFAULT_SORT_TAGS, SORT_LABELS } from '@/pages/search/constants/index';
 import { headerRootCutomStyle } from '@/pages/search/index.css';
@@ -12,14 +12,22 @@ import { genreEngMapping, levelEngMapping } from '@/constants';
 import { labelToSortOptionMap } from '@/constants';
 
 const Search = () => {
+  const [searchParams] = useSearchParams();
+  const genreFromParams = useMemo(() => searchParams.get('genre'), [searchParams]);
+
   const [searchValue, setSearchValue] = useState('');
   const [submittedSearchValue, setSubmittedSearchValue] = useState('');
-  const [genre, setGenre] = useState<string | null>(null);
+  const [genre, setGenre] = useState<string | null>(genreFromParams || null);
   const [level, setLevel] = useState<string | null>(null);
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [selectedLabel, setSelectedLabel] = useState<keyof typeof labelToSortOptionMap>(SORT_LABELS.LATEST);
-  const [hasSearched, setHasSearched] = useState(false);
+
+  useMemo(() => {
+    if (genreFromParams) {
+      setGenre(genreFromParams);
+    }
+  }, [genreFromParams]);
 
   const sortOption = labelToSortOptionMap[selectedLabel];
 
@@ -42,7 +50,6 @@ const Search = () => {
 
   const handleSearchIconClick = () => {
     setSubmittedSearchValue(searchValue);
-    setHasSearched(true);
   };
 
   return (
@@ -55,28 +62,23 @@ const Search = () => {
           handleSearchIconClick={handleSearchIconClick}
         />
       </Header.Root>
-      {!hasSearched ? (
-        <Flex paddingTop="7.9rem" paddingLeft="2rem">
-          <SearchIntro />
-        </Flex>
-      ) : (
-        <TabContainer
-          defaultSortTags={DEFAULT_SORT_TAGS}
-          genre={genre}
-          level={level}
-          startDate={startDate}
-          endDate={endDate}
-          setGenre={setGenre}
-          setLevel={setLevel}
-          setStartDate={setStartDate}
-          setEndDate={setEndDate}
-          dancerList={dancerList}
-          classList={classList}
-          error={error}
-          selectedLabel={selectedLabel}
-          setSelectedLabel={setSelectedLabel}
-        />
-      )}
+
+      <TabContainer
+        defaultSortTags={DEFAULT_SORT_TAGS}
+        genre={genre}
+        level={level}
+        startDate={startDate}
+        endDate={endDate}
+        setGenre={setGenre}
+        setLevel={setLevel}
+        setStartDate={setStartDate}
+        setEndDate={setEndDate}
+        dancerList={dancerList}
+        classList={classList}
+        error={error}
+        selectedLabel={selectedLabel}
+        setSelectedLabel={setSelectedLabel}
+      />
     </Flex>
   );
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SearchBar from '@/pages/search/components/SearchBar';
 import TabContainer from '@/pages/search/components/TabContainer';
@@ -13,21 +13,16 @@ import { labelToSortOptionMap } from '@/constants';
 
 const Search = () => {
   const [searchParams] = useSearchParams();
-  const genreFromParams = useMemo(() => searchParams.get('genre'), [searchParams]);
+  const initialGenre = searchParams.get('genre');
+
+  const [genre, setGenre] = useState<string | null>(() => initialGenre || null);
 
   const [searchValue, setSearchValue] = useState('');
   const [submittedSearchValue, setSubmittedSearchValue] = useState('');
-  const [genre, setGenre] = useState<string | null>(genreFromParams || null);
   const [level, setLevel] = useState<string | null>(null);
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [selectedLabel, setSelectedLabel] = useState<keyof typeof labelToSortOptionMap>(SORT_LABELS.LATEST);
-
-  useMemo(() => {
-    if (genreFromParams) {
-      setGenre(genreFromParams);
-    }
-  }, [genreFromParams]);
 
   const sortOption = labelToSortOptionMap[selectedLabel];
 

--- a/src/routes/routesConfig.ts
+++ b/src/routes/routesConfig.ts
@@ -21,15 +21,15 @@ export const ROUTES_CONFIG = {
   },
   class: {
     title: 'Class',
-    path: (id:string) => `/class/${id}`,
+    path: (id: string) => `/class/${id}`,
   },
   dancer: {
     title: 'Dancer',
-    path: (id:string) => `/dancer/${id}`,
+    path: (id: string) => `/dancer/${id}`,
   },
   reservation: {
     title: 'Reservation',
-    path: (id:string) => `/reservation/${id}`,
+    path: (id: string) => `/reservation/${id}`,
   },
   payments: {
     title: 'payments',


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #230 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->


## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
### useGetDancerDetail의 쿼리키 수정
기존의 쿼리키에 `teacherId`를 추가해주었습니다. 추가하기 전에는 댄서리스트를 클릭하면 댄서 상세페이지로 넘어가지만 그 이후에는 처음에 접속했던 댄서 상세페이지만 화면에 뜨는 문제가 발생. 왜냐하면 `React Router`에서 동일한 라우트에 대해 상태가 유지되기 때문이었습니다. 즉, 같은 컴포넌트가 렌더링되고 있지만 새로운 `id`가 넘어와도 컴포넌트 내부의 로직이 트리거되지 않는 문제가 발생.(업데이트가 안되고 기존의 컴포넌트를 재사용하고 있음). 쿼리키에 `teacherId`를 추가해주니 `teacherId`가 변경될 때마다 컴포넌트가 트리거 되도록 하였습니다.

### 홈페이지에서 인기있는 장르 클릭시 해당 장르가 선택된 채로 `search`페이지가 열리도록 구현.
`navigate`를 통해 장르 클릭시 해당 장르를 `url`에 담아서 보내고, `search` 페이지에서 `searchParams`를 통해 추출해서 사용하도록 하였습니다.(영상 참고)
일단, 해당 방식으로 구현했는데 문제가 발생했습니다.
새로고침을 했을 때도 마찬가지로 `searchParams`를 통해 `genre`를 추출해서 사용하는 문제가 있습니다. 장르 선택이 초기화 되지 않음.(영상 참고)

그래서, `navigate`로 상태를 `search`페이지로 전달하고 다음과 같이 추출해서 사용하도록 하였습니다. 그러나, 새로고침시 상태가 초기화 되지 않는 문제가 발생하였습니다. 해당 부분은 추후에 더 공부해 봐야될 것 같아요. 제가 알고있던 지식으로는 상태가 초기화 되어야하는데..

```typescript
const location = useLocation();
const navigate = useNavigate();
const initialGenre = location.state?.genre || null;
```
  
https://github.com/user-attachments/assets/2cabbd45-1fb9-47ac-ac00-feb9ed406324

해당 문제를 제대로 해결하기 위해서 어쩔 수 없이 `useEffect`를 사용해서 해결하긴 했는데, 추후에 리팩토링 하면서 다른 방안을 찾아보도록 하겠습니다. 혹시 해결방안 있으시면 의견 달아주세요!




## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

https://github.com/user-attachments/assets/1a91c931-abab-41c8-b1e0-64d0274fb405


https://github.com/user-attachments/assets/8731f128-71ae-4c0e-ba6c-61ad18db021a




## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

