### PR TITLE
[Feat] 토스페이먼츠 결제 api 연동

### DIFF
--- a/src/apis/reservation/axios/index.ts
+++ b/src/apis/reservation/axios/index.ts
@@ -1,6 +1,6 @@
-import { instance } from '@/apis/api';
-import { API_URL } from "@/apis/constants/apiURL";
 import { ReservationDetailApiResponse } from '@/pages/reservation/types';
+import { instance } from '@/apis/api';
+import { API_URL } from '@/apis/constants/apiURL';
 
 export const getReservation = async (lessonId: string): Promise<ReservationDetailApiResponse> => {
   const url = `${API_URL.LESSON_RESERVE_PROGRESS}/${lessonId}/reserve-progress`;
@@ -10,8 +10,15 @@ export const getReservation = async (lessonId: string): Promise<ReservationDetai
 
 export const postReservation = async (
   lessonId: string,
+  paymentKey: string,
+  orderId: string,
+  amount: number
 ): Promise<ReservationDetailApiResponse> => {
   const url = `${API_URL.LESSON_RESERVATION}/${lessonId}/reservations`;
-  const { data } = await instance.post(url);
+  const { data } = await instance.post(url, {
+    paymentKey,
+    orderId,
+    amount,
+  });
   return data;
 };

--- a/src/apis/reservation/queries/index.ts
+++ b/src/apis/reservation/queries/index.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { ReservationDetailApiResponse } from '@/pages/reservation/types';
+import { QUERY_KEYS } from '@/apis/constants/queryKey';
 import { getReservation, postReservation } from '@/apis/reservation/axios';
-import { ReservationDetailApiResponse } from "@/pages/reservation/types";
-import { QUERY_KEYS } from "@/apis/constants/queryKey";
-import { AxiosError } from "axios";
 
 export const useGetReservaion = (lessonId: string) => {
   return useQuery<ReservationDetailApiResponse, AxiosError>({
@@ -12,7 +12,11 @@ export const useGetReservaion = (lessonId: string) => {
 };
 
 export const usePostReservation = () => {
-  return useMutation<ReservationDetailApiResponse, AxiosError, { lessonId: string; }>({
-    mutationFn: ({ lessonId }) => postReservation(lessonId),
+  return useMutation<
+    ReservationDetailApiResponse,
+    AxiosError,
+    { lessonId: string; paymentKey: string; orderId: string; amount: number }
+  >({
+    mutationFn: ({ lessonId, paymentKey, orderId, amount }) => postReservation(lessonId, paymentKey, orderId, amount),
   });
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,6 +3,7 @@ import React, { ComponentPropsWithoutRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Head from '@/components/Head';
 import { backIconStyle, closeIconStyle, headerRootStyle, titleStyle } from '@/components/Header/index.css';
+import { ROUTES_CONFIG } from '@/routes/routesConfig';
 import { IcBack, IcClose } from '@/assets/svg';
 
 interface HeaderRootProps extends ComponentPropsWithoutRef<'div'> {
@@ -12,6 +13,7 @@ interface HeaderRootProps extends ComponentPropsWithoutRef<'div'> {
 
 interface BackIconProps {
   onFunnelBackClick?: () => void;
+  onHomeBackClick?: () => void;
 }
 
 interface TitleProps {
@@ -30,12 +32,16 @@ const HeaderRoot = ({ children, isColor = false, className }: HeaderRootProps): 
   return <div className={clsx(className, headerRootStyle({ isColor }))}>{children}</div>;
 };
 
-const BackIcon = ({ onFunnelBackClick }: BackIconProps): JSX.Element => {
+const BackIcon = ({ onFunnelBackClick, onHomeBackClick }: BackIconProps): JSX.Element => {
   const navigate = useNavigate();
   const handleBackClick = () => {
-    // Funnel 구조에서는 이전 버튼 누를 시 setStep(-1)을 해준다.
     if (onFunnelBackClick) {
       onFunnelBackClick();
+      return;
+    }
+
+    if (onHomeBackClick) {
+      navigate(ROUTES_CONFIG.home.path);
       return;
     }
 

--- a/src/pages/mypage/mypageReservation/index.tsx
+++ b/src/pages/mypage/mypageReservation/index.tsx
@@ -23,10 +23,14 @@ const MyPageReservation = () => {
       navigate(ROUTES_CONFIG.error.path);
     }
   };
+
+  const handleNavigateHome = () => {
+    navigate('/');
+  };
   return (
     <div className={layoutStyle}>
       <Header.Root isColor={true}>
-        <Header.BackIcon />
+        <Header.BackIcon onHomeBackClick={handleNavigateHome} />
         <Header.Title title="클래스 예약 내역" />
       </Header.Root>
 

--- a/src/pages/reservation/components/TossPayments/CheckOut/CheckOut.tsx
+++ b/src/pages/reservation/components/TossPayments/CheckOut/CheckOut.tsx
@@ -1,5 +1,6 @@
 import { loadTossPayments, ANONYMOUS } from '@tosspayments/tosspayments-sdk';
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import * as styles from '@/pages/reservation/components/TossPayments/index.css';
 
 const generateRandomString = () => window.btoa(String(Math.random())).slice(0, 20);
@@ -7,15 +8,23 @@ const generateRandomString = () => window.btoa(String(Math.random())).slice(0, 2
 const clientKey = 'test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm';
 
 export const CheckoutPage = () => {
+  const location = useLocation();
+  const lessonId = location.state?.lessonId;
+  const totalPrice = location.state?.totalPrice;
+  const className = location.state?.className;
+  const stundentName = location.state?.studentName;
+
   const [ready, setReady] = useState(false);
   const [widgets, setWidgets] = useState<any>(null);
   const [amount, setAmount] = useState({
     currency: 'KRW',
-    value: 45_000,
+    value: totalPrice,
   });
 
   console.log(ready); // 빌드 에러 잡는 용 추후 사용 예정
   console.log(setAmount); // 빌드 에러 잡는 용 추후 사용 예정
+
+  console.log(totalPrice);
 
   useEffect(() => {
     const fetchPaymentWidgets = async () => {
@@ -54,14 +63,13 @@ export const CheckoutPage = () => {
     try {
       await widgets?.requestPayment({
         orderId: generateRandomString(),
-        orderName: '토스 티셔츠 외 2건',
-        customerName: '김토스',
+        orderName: className,
+        customerName: stundentName,
         customerEmail: 'customer123@gmail.com',
-        successUrl: window.location.origin + '/reservation/payments/success' + window.location.search,
-        failUrl: window.location.origin + '/reservation/payments/fail' + window.location.search,
+        successUrl: `${window.location.origin}/reservation/payments/success?lessonId=${lessonId}${window.location.search}`,
+        failUrl: `${window.location.origin}/reservation/payments/fail${window.location.search}`,
       });
     } catch (error) {
-      // TODO: 에러 처리
       console.error('결제 요청 중 오류 발생:', error);
     }
   };

--- a/src/pages/reservation/components/TossPayments/CheckOut/CheckOut.tsx
+++ b/src/pages/reservation/components/TossPayments/CheckOut/CheckOut.tsx
@@ -24,8 +24,6 @@ export const CheckoutPage = () => {
   console.log(ready); // 빌드 에러 잡는 용 추후 사용 예정
   console.log(setAmount); // 빌드 에러 잡는 용 추후 사용 예정
 
-  console.log(totalPrice);
-
   useEffect(() => {
     const fetchPaymentWidgets = async () => {
       const tossPayments = await loadTossPayments(clientKey);

--- a/src/pages/reservation/components/TossPayments/index.css.ts
+++ b/src/pages/reservation/components/TossPayments/index.css.ts
@@ -3,7 +3,6 @@ import { style, globalStyle } from '@vanilla-extract/css';
 export const wrapper = style({
   display: 'flex',
   alignItems: 'center',
-  padding: '2.4rem',
   overflow: 'auto',
 });
 

--- a/src/pages/reservation/index.tsx
+++ b/src/pages/reservation/index.tsx
@@ -16,16 +16,16 @@ import {
   bottomButtonStyle,
   agreementTextStyle,
 } from '@/pages/reservation/index.css';
+import { LessonRoundProps } from '@/pages/reservation/types';
 import BoxButton from '@/components/BoxButton';
 import Divider from '@/components/Divider';
 import Flex from '@/components/Flex';
 import Head from '@/components/Head';
 import Header from '@/components/Header';
 import Text from '@/components/Text';
-import { useGetReservaion, usePostReservation } from '@/apis/reservation/queries';
+import { useGetReservaion } from '@/apis/reservation/queries';
 import { ROUTES_CONFIG } from '@/routes/routesConfig';
 import { IcCheckcircleGray0524, IcCheckcircleMain0324 } from '@/assets/svg';
-import { LessonRoundProps } from '@/pages/reservation/types';
 
 const Reservation = () => {
   const [isAllChecked, setIsAllChecked] = useState(false);
@@ -39,8 +39,6 @@ const Reservation = () => {
   }
 
   const { data, isError, isLoading } = useGetReservaion(id);
-  const { mutate: classReservation } = usePostReservation();
-  const [hasError, setHasError] = useState(false);
 
   if (isLoading) {
     return <></>;
@@ -67,28 +65,20 @@ const Reservation = () => {
 
   const totalPrice = data.lessonRound.lessonRounds.length * data.price;
 
+  const className = data.name;
+
+  const studentName = data.studentName;
+
   const lessonRounds: LessonRoundProps[] = data.lessonRound.lessonRounds.map((round) => ({
     startDateTime: round.startDateTime,
     endDateTime: round.endDateTime,
   }));
 
   const handleButtonClick = async () => {
-    classReservation(
-      { lessonId: id },
-      {
-        onSuccess: () => {
-          navigate(ROUTES_CONFIG.mypageReservation.path);
-        },
-        onError: () => {
-          setHasError(true);
-        },
-      }
-    );
+    {
+      navigate(ROUTES_CONFIG.payments.path, { state: { lessonId: id, totalPrice, className, studentName } });
+    }
   };
-
-  if (hasError) {
-    return <Error />;
-  }
 
   return (
     <Flex direction="column" width="100%" className={reservationStyle}>


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #272  


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
- 토스페이먼츠 결제 api 연동
- 클래스 예약 내역에서 `<` 아이콘 클릭시 무조건 home으로 이동하도록 수정
- 클래스 신청 페이지에서 가격, 클래스명, 신청자 명, 결제 페이지로 넘겨주도록 수정 


## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->


## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

https://github.com/user-attachments/assets/8a71b025-7aa0-493f-931a-fc092d024752

모바일로 결제 진행하면 토스 어플 열리기 때문에 자연스럽게 진행 될 겁니다!

## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

