### PR TITLE
[Fix] Input 공통 컴포넌트 focus 문제 해결

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,6 @@
 import type { Preview } from '@storybook/react';
-import '../src/styles/global.css';
-import '../src/styles/reset.css';
+import '../src/shared/styles/global.css';
+import '../src/shared/styles/reset.css';
 
 const preview: Preview = {
   parameters: {

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -16,7 +16,7 @@ const Input = (
   const handleFocus = () => setIsFocused(true);
   const handleBlur = () => setIsFocused(false);
 
-  const ifTextFieldActivated = isFocused && !isError;
+  const isTextFieldActivated = isFocused && !isError;
 
   return (
     <input
@@ -25,7 +25,7 @@ const Input = (
       className={clsx(
         className,
         style.inputStyle({
-          ifTextFieldActivated,
+          isTextFieldActivated,
           isError,
           isSearch,
         })

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -16,7 +16,7 @@ const Input = (
   const handleFocus = () => setIsFocused(true);
   const handleBlur = () => setIsFocused(false);
 
-  const isTextFieldActivated = isFocused && !isError;
+  const isActive = isFocused && !isError;
 
   return (
     <input
@@ -25,7 +25,7 @@ const Input = (
       className={clsx(
         className,
         style.inputStyle({
-          isTextFieldActivated,
+          isActive,
           isError,
           isSearch,
         })
@@ -34,6 +34,7 @@ const Input = (
       onBlur={handleBlur}
       value={value}
       {...props}
+      aria-invalid={isError ? 'true' : 'false'}
     />
   );
 };

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -16,7 +16,21 @@ const Input = (
   const handleFocus = () => setIsFocused(true);
   const handleBlur = () => setIsFocused(false);
 
-  const isActive = isFocused && !isError;
+  // const isActive = isFocused && !isError;
+
+  const defineInputState = (isError?: boolean, isFocused?: boolean, isSearch?: boolean) => {
+    if (isError) {
+      return 'error';
+    }
+
+    if (isSearch) {
+      return 'search';
+    } else if (isFocused) {
+      return 'focus';
+    }
+  };
+
+  const inputState = defineInputState(isError, isFocused, isSearch);
 
   return (
     <input
@@ -25,9 +39,9 @@ const Input = (
       className={clsx(
         className,
         style.inputStyle({
-          isActive,
-          isError,
-          isSearch,
+          defineInputState: inputState,
+          // isError,
+          // isSearch,
         })
       )}
       onFocus={handleFocus}

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -16,7 +16,7 @@ const Input = (
   const handleFocus = () => setIsFocused(true);
   const handleBlur = () => setIsFocused(false);
 
-  const hasValue = value !== undefined && value !== null && value !== '';
+  const ifTextFieldActivated = isFocused && !isError;
 
   return (
     <input
@@ -25,10 +25,10 @@ const Input = (
       className={clsx(
         className,
         style.inputStyle({
-          isError: hasValue ? isError : undefined,
+          ifTextFieldActivated,
+          isError,
           isSearch,
-        }),
-        { [style.focusStyle]: isFocused && !hasValue }
+        })
       )}
       onFocus={handleFocus}
       onBlur={handleBlur}

--- a/src/shared/components/Input/input.css.ts
+++ b/src/shared/components/Input/input.css.ts
@@ -24,12 +24,14 @@ export const inputStyle = recipe({
     },
   },
   variants: {
+    isTextFieldActivated: {
+      true: {
+        outline: `1px solid ${vars.colors.main04}`,
+      },
+    },
     isError: {
       true: {
         border: `1px solid ${vars.colors.alert03}`,
-      },
-      false: {
-        border: `1px solid ${vars.colors.main04}`,
       },
     },
     isSearch: {
@@ -42,6 +44,4 @@ export const inputStyle = recipe({
   },
 });
 
-export const focusStyle = style({
-  outline: `1px solid ${vars.colors.main04}`,
-});
+export const focusStyle = style({});

--- a/src/shared/components/Input/input.css.ts
+++ b/src/shared/components/Input/input.css.ts
@@ -24,18 +24,14 @@ export const inputStyle = recipe({
     },
   },
   variants: {
-    isActive: {
-      true: {
+    defineInputState: {
+      focus: {
         outline: `1px solid ${vars.colors.main04}`,
       },
-    },
-    isError: {
-      true: {
+      error: {
         border: `1px solid ${vars.colors.alert03}`,
       },
-    },
-    isSearch: {
-      true: {
+      search: {
         borderRadius: '90px',
         padding: '1rem 4rem 1rem 4.6rem',
         ...vars.fonts.b2,

--- a/src/shared/components/Input/input.css.ts
+++ b/src/shared/components/Input/input.css.ts
@@ -24,7 +24,7 @@ export const inputStyle = recipe({
     },
   },
   variants: {
-    isTextFieldActivated: {
+    isActive: {
       true: {
         outline: `1px solid ${vars.colors.main04}`,
       },
@@ -43,5 +43,3 @@ export const inputStyle = recipe({
     },
   },
 });
-
-export const focusStyle = style({});

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -9,6 +9,14 @@ globalStyle(':root', {
   },
 });
 
+// storybook의 경우는 모바일 view 적용 안되도록 처리
+globalStyle(':root:has(#storybook-root)', {
+  vars: {
+    '--min-width': 'auto',
+    '--max-width': 'auto',
+  },
+});
+
 globalStyle(':root', {
   vars: {
     '--swiper-theme-color': vars.colors.white,

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Input from '@/shared/components/Input/Input';
+
+const meta = {
+  title: 'Common/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    placeholder: 'placeholder',
+    isError: false,
+    value: 'value',
+  },
+};


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #328 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
공통 컴포넌트 Input의 focus가 제대로 유지되지 않는 문제를 해결하였습니다. 
추가로 Input의 storybook 코드를 작성하였습니다.

## ⭐ PR Point (To Reviewer)
Input 공통 컴포넌트의 focus가 유지되지 않는 문제를 focus css 조건이 잘못되었다고 판단했고, 이를 수정하였습니다!

제가 구현해야 할 Input 공통 컴포넌트의 focus 조건은 다음과 같습니다.

1. 기본적으로 input에 focus하면 **main color**가 테두리에 적용된다. blur의 경우 이를 제거한다.
2. 값을 입력하는 경우에도 focus의 상태로 판단하므로 1번을 동일하게 적용한다.
3. blur인 경우에는 값이 있어도 border는 없어야 한다.
4. 유효성 검사 유무에 따라 조건 분기를 한다.
  a. `유효성 검사가 있다면` - `isError`가 true라면 1번의 focus css는 무시되어야 한다. focus main color 대신 isError에 해당하는 **alert2(red) color**를 테두리 색으로 적용한다.
  b. `유효성 검사가 없다면` - 1번 상황을 그대로 적용

**간단하게 요약하자면 값의 유무와 상관없이 focus 된 경우에는 border(main color)가 적용되어야 하고, props로 isError의 값이 true로 넘어올 경우 focus 유무와 관계없이 main color border를 무시하고, border(alert2)가 적용되어야 한다는 것입니다.** 

![image](https://github.com/user-attachments/assets/f11fc11b-45c6-4416-aca2-8890aaa7e805)



기존에는 해당 구현을 위해 아래와 같이 작성이 되어 있었습니다.

### [기존 코드]
```ts
const hasValue = value !== undefined && value !== null && value !== '';

return (
    <input
      ref={ref}
      type="text"
      className={clsx(
        className,
        style.inputStyle({
          isError: hasValue ? isError : undefined,
          isSearch,
        }),
        { [style.focusStyle]: isFocused && !hasValue }
      )}
// ...
```

하지만 피그마 조건 상으로 값의 유무는 focus style 여부에 영향을 주지 않기 때문에 해당 코드를 아래와 같이 수정하였습니다.

<br/>
<br/>


### [수정 코드]

```ts
// Input.tsx

// focus가 되어 있고, Error가 false일 경우만 isTextFieldActivated를 true로 설정한다.
const isTextFieldActivated = isFocused && !isError;

  return (
    <input
      ref={ref}
      type="text"
      className={clsx(
        className,
        style.inputStyle({
          isTextFieldActivated,
          isError,
          isSearch,
        })
      )}
  // ...
```
```ts
// input.css.ts

variants: {
    isTextFieldActivated: {
      true: {
        outline: `1px solid ${vars.colors.main04}`,
      },
    },
    isError: {
      true: {
        border: `1px solid ${vars.colors.alert03}`,
      },
    },
  // ...
```

<br/>



## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

https://github.com/user-attachments/assets/3b98ea97-bdf9-4152-8cd3-367d0f79b48e



## 🔔 ETC
해당 input에 대해 storybook 코드를 작성하고 확인하던 중 예상하지 못한 이슈를 발견했습니다!
DA/SH 프로젝트가 모바일 환경으로 view가 보여져야 하기 때문에 설정한 globalStyle인 `min/max-width`설정이 `storybook docs`에도 적용이 된다는 사실입니다.

<br/>

![image](https://github.com/user-attachments/assets/1572fd3b-e5c2-418a-9711-77f2106206ce)


결국 root에 globalStyle을 주는데 storybook도 결국 해당 html위에서 구동이 되기 때문에 이 globalStyle 설정이 같이 적용된다는 것이 원이었습니다. 

<br/>

따라서 storybook에는 이 globalStyle이 적용이 안되도록 설정하는 것이 해결책이라고 생각했고 제가 생각한 방법은 2가지로 아래와 같습니다.

1. `preview.css`에서 `!important;`를 사용해 storybook 환경에서 다른 스타일을 덮어 씌우기
2. `:has`로 storybook 환경만 다른 스타일 주기

1번은 storybook의 view를 담당하는 `preview.ts`에 css를 적용하는 `preview.css`를 만들어 `!important;`로 강제 다른 스타일을 덮어 씌우는 방법입니다. 

```ts
// 1번 예시 코드

:root {
  --min-width: auto !important;
  --max-width: auto !important;
}
```

하지만 해당  `!important;`는 css의 우선 순위 체계를 파괴한다고 생각하여 2번을 선택하여 이 문제를 해결하였습니다. 

<br/>

![image](https://github.com/user-attachments/assets/d14e52ca-e7e5-45c1-aaf8-4d1f63805a68)

위 사진과 같이 storybook 환경에서는 html문서에 id가 `#storybook-root`라는 이름으로 element가 추가되는 것을 확인할 수 있었고, root가 만약  이 `#storybook-root`이라는 id를 가지면 storybook 환경이라는 것을 알 수 있었습니다. 따라서 아래와 같이 `:has`를 통해 해당 조건으로 storybook 환경에서는 `auto` 값을 주도록 분기 처리를 하였습니다.

```ts

// 2번 예시 코드
globalStyle(':root:has(#storybook-root)', {
  vars: {
    '--min-width': 'auto',
    '--max-width': 'auto',
  },
});
```

<br/>

일단 2번으로 해결하기는 했는데, 제가 정확한 원인을 파악한 것이 맞는지 그리고 해결 방법이 괜찮은 방법일지 같이 생각해주시면 감사하겠습니다!! 



