### PR TITLE
[Setting] Kakao Redirect URI env로 변경 & prod 환경 분리

### DIFF
--- a/src/pages/auth/auth.ts
+++ b/src/pages/auth/auth.ts
@@ -12,7 +12,7 @@ export const LoginCallback = () => {
   const { mutate: login } = useLoginMutation();
 
   useEffect(() => {
-    if (code) login({ redirectUrl: 'http://localhost:5173/auth', code });
+    if (code) login({ redirectUrl: import.meta.env.VITE_KAKAO_REDIRECT_URI, code });
   }, [code]);
 
   // 잠시 인가 코드만 추출해서 api를 보내는 페이지이기 때문에 null 값 반환

--- a/src/pages/login/components/KakaoButton/KakaoButton.tsx
+++ b/src/pages/login/components/KakaoButton/KakaoButton.tsx
@@ -4,10 +4,11 @@ import Flex from '@/shared/components/Flex/Flex';
 import Head from '@/shared/components/Head/Head';
 
 const KakaoButton = () => {
-  const redirect_uri = 'http://localhost:5173/auth'; //Redirect URI
+  const redirect_uri = import.meta.env.VITE_KAKAO_REDIRECT_URI; //Redirect URI
 
   // auth 요청 URL
   const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_REST_API_KEY}&redirect_uri=${redirect_uri}&response_type=code`;
+
   const handleLogin = () => {
     window.location.href = kakaoURL;
   };


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #342  


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
해당 작업은 매번 테스트 할 때마다 Kakao 소셜 로그인 Redirect URI를 바꿔야 하는 불편함으로부터 시작되었습니다.
QA 혹은 실제 배포 환경에서 잘 작동하는지 테스트를 하려면 `prod` 환경의 URI가 필요했고, 테스트 진행 후 다시 개발에 들어갈 때는 다시 `dev`환경의 URI를 바꾸는 과정이 불편하고 불필요한 리소스 낭비라고 생각했습니다.

또한 애초에 Redirect URI가 하드 코딩 되어 상수로 직접 지정하여 쓰는 것은 변경이 있을 때마다 여러 파일에 접근해 수정해야 하는 불편함도 있었으며, 노출할 필요도 없다고 생각했습니다.

따라서 이를 `env`파일에 환경 변수로 지정하여 사용하도록 변경하였습니다. 또한 각자 local 환경에서는 `env`에 `local` 환경 전용 URI를 쓰고 작업을 하고, 배포한 vercel에서 `local`과 `prod`환경을 분리하여 `env`가 적용되도록 설정하였습니다.


## ⭐ PR Point (To Reviewer)
해당 방법은 vercel에서 2가지 환경을 구분하여 `env`를 적용하는 방법인데, 혹시나 이 방법 외에 좋은 방법이 있거나 해당 접근에 단점이 있다면 편하게 말해주시면 감사하겠습니다 :)


## 📷 Screenshot
![image](https://github.com/user-attachments/assets/a55b1f7e-2364-43a1-8ad7-7ec65ccf77a3)


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

