### PR TITLE
[Fix] modal 컴포넌트 버튼 텍스트 주입 가능하도록 개선

### DIFF
--- a/src/common/components/Modal/Modal.tsx
+++ b/src/common/components/Modal/Modal.tsx
@@ -13,11 +13,18 @@ interface DialogProps {
   type: 'default' | 'single';
   onClose: () => void;
   onClickHandler?: () => void;
-  cancelText?: string;
-  confirmText?: string;
+  leftButtonText?: string;
+  rightButtonText?: string;
 }
 
-const Modal = ({ content, type, onClose, onClickHandler, cancelText = '취소', confirmText = '확인' }: DialogProps) => {
+const Modal = ({
+  content,
+  type,
+  onClose,
+  onClickHandler,
+  leftButtonText = '취소',
+  rightButtonText = '확인',
+}: DialogProps) => {
   const handleCheckButtonClick = () => {
     if (onClickHandler) {
       onClickHandler();
@@ -34,16 +41,16 @@ const Modal = ({ content, type, onClose, onClickHandler, cancelText = '취소', 
           {type === 'default' && (
             <>
               <button onClick={onClose} className={closeButtonStyle}>
-                {cancelText}
+                {leftButtonText}
               </button>
               <BoxButton variant="primary" onClick={handleCheckButtonClick}>
-                {confirmText}
+                {rightButtonText}
               </BoxButton>
             </>
           )}
           {type === 'single' && (
             <BoxButton variant="primary" onClick={handleCheckButtonClick}>
-              {confirmText}
+              {rightButtonText}
             </BoxButton>
           )}
         </div>


### PR DESCRIPTION
## 📌 Related Issues
- close #582 

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
modal 컴포넌트 버튼 텍스트 주입 가능하도록 개선

## ⭐ PR Point 

## 📷 Screenshot
### 예시
<img width="411" height="798" alt="Monosnap Image 2025-10-30 16-52-58" src="https://github.com/user-attachments/assets/b2edb1a6-d4de-4bfb-b3b8-c7b79eed399a" />

### 사용시
<img width="388" height="191" alt="Monosnap Image 2025-10-30 16-59-56" src="https://github.com/user-attachments/assets/fbaa5aaa-e5ac-4553-adb0-2bdbea36b244" />



## 🔔 ETC
