### PR TITLE
fix: BFF 프록시 Host 헤더 수정

### DIFF
--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -13,6 +13,10 @@ async function proxyToBackend(request: NextRequest, params: RouteParams) {
 
     const proxyRequest = new Request(targetUrl, request);
 
+    // 원본 요청의 Host 헤더(da-sh.kr)가 그대로 전달되면
+    // 백엔드 서버가 잘못된 vhost로 라우팅할 수 있으므로 대상 서버의 host로 덮어쓴다
+    proxyRequest.headers.set('Host', targetUrl.host);
+
     const cookieAccessToken = request.cookies.get(ACCESS_TOKEN_KEY)?.value;
     const cookieTempAccessToken = request.cookies.get(TEMP_ACCESS_TOKEN_KEY)?.value;
     const accessToken = cookieAccessToken ?? cookieTempAccessToken;


### PR DESCRIPTION
## Summary
- BFF 프록시 요청 시 원본 요청의 `Host` 헤더(`da-sh.kr`)가 백엔드(`dev.da-sh.kr`)에 그대로 전달되어 잘못된 vhost로 라우팅되는 문제 수정
- CSR 요청이 JSON 대신 홈 화면 HTML을 반환하던 이슈 해결
- `proxyRequest.headers.set('Host', targetUrl.host)` 한 줄 추가

## Test plan
- [ ] 배포 후 CSR API 요청이 JSON으로 정상 응답되는지 확인
- [ ] 로그인/비로그인 상태 모두에서 API 호출 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)