### PR TITLE
fix: BFF 프록시 Host 헤더 수정

### DIFF
--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -13,6 +13,10 @@ async function proxyToBackend(request: NextRequest, params: RouteParams) {
 
     const proxyRequest = new Request(targetUrl, request);
 
+    // 원본 요청의 Host 헤더(da-sh.kr)가 그대로 전달되면
+    // 백엔드 서버가 잘못된 vhost로 라우팅할 수 있으므로 대상 서버의 host로 덮어쓴다
+    proxyRequest.headers.set('Host', targetUrl.host);
+
     const cookieAccessToken = request.cookies.get(ACCESS_TOKEN_KEY)?.value;
     const cookieTempAccessToken = request.cookies.get(TEMP_ACCESS_TOKEN_KEY)?.value;
     const accessToken = cookieAccessToken ?? cookieTempAccessToken;


### PR DESCRIPTION
## Summary
- #691 과 동일한 변경사항을 develop에 반영
- BFF 프록시 요청 시 `Host` 헤더를 대상 서버 도메인으로 설정하여 CSR 요청이 홈 HTML로 응답되던 문제 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)